### PR TITLE
Implement assignment deadline types and late submission handling

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,28 @@
+Resolves #
+
+## Overview
+<!---
+  Include the number of the issue addressed by this PR above, if applicable.
+  PRs for code changes without an associated issue *will not be merged*.
+  See CONTRIBUTING.md for more information.
+
+  Add the `user docs` label to this PR if it will need docs changes.  An
+  issue will get opened in docs.getdbt.com upon successful merge of this PR.
+-->
+
+## Details
+
+## Changes outside the codebase
+*If you have made changes to external services, need to add additional values to the job settings, or need to add something new to the database, explain it here. This may include updates to third-party services, changes to infrastructure configuration, integration with external APIs, etc.*
+
+## Additional information
+*Provide any additional information that might be useful to the reviewer in evaluating this pull request. This could include performance considerations,design choices, etc.*
+
+### Checklist
+
+- [ ] I have run this code in development, and it appears to resolve the stated issue.
+- [ ] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval.
+- [ ] My pull request represents one logical piece of work.
+- [ ] My commits are related to the pull request and look clean.
+- [ ] I have added appropriate tests and documentation to any new models.
+- [ ] I have updated the README file if appropriate.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
     paths-ignore:
       - "**/*.md"
       - "docs/**"
+      - ".gitignore"
   pull_request:
     branches:
       - main

--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,4 @@ apps/web/Cargo.lock
 /apps/web/.sass-cache/
 
 apps/web/assets/private/document/**
+/.sass-cache/

--- a/apps/libgrader/src/domains/assignments.rs
+++ b/apps/libgrader/src/domains/assignments.rs
@@ -24,7 +24,8 @@ mod infra {
 
 pub use api::routes::assignment_routes;
 pub use domain::model::{
-    Assignment, AssignmentAttachment, AssignmentWithAttachmentCount, StudentAssignmentSubmission,
+    Assignment, AssignmentAttachment, AssignmentDeadlineType, AssignmentWithAttachmentCount,
+    StudentAssignmentSubmission,
 };
 pub use domain::repository::AssignmentRepositoryTrait;
 pub use domain::service::AssignmentServiceTrait;

--- a/apps/libgrader/src/domains/assignments/domain/model.rs
+++ b/apps/libgrader/src/domains/assignments/domain/model.rs
@@ -1,6 +1,15 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use sqlx::FromRow;
+use utoipa::ToSchema;
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, ToSchema, sqlx::Type, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+#[sqlx(type_name = "assignment_deadline_type_enum", rename_all = "snake_case")]
+pub enum AssignmentDeadlineType {
+    HardCutoff,
+    SoftDeadline,
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
 pub struct Assignment {
@@ -9,6 +18,7 @@ pub struct Assignment {
     pub title: String,
     pub description: Option<String>,
     pub due_at: Option<DateTime<Utc>>,
+    pub deadline_type: AssignmentDeadlineType,
     pub points: Option<i16>,
     pub created_by: Option<uuid::Uuid>,
     pub created_at: Option<DateTime<Utc>>,
@@ -40,6 +50,8 @@ pub struct StudentAssignmentSubmission {
     pub file_size: i64,
     pub submitted_by: uuid::Uuid,
     pub submitted_at: DateTime<Utc>,
+    pub deadline_type: AssignmentDeadlineType,
+    pub is_late: bool,
     pub grading_status: Option<String>,
     pub grading_completed_at: Option<DateTime<Utc>>,
 }
@@ -52,6 +64,7 @@ pub struct AssignmentWithAttachmentCount {
     pub title: String,
     pub description: Option<String>,
     pub due_at: Option<DateTime<Utc>>,
+    pub deadline_type: AssignmentDeadlineType,
     pub created_by: Option<uuid::Uuid>,
     pub created_at: Option<DateTime<Utc>>,
     pub modified_by: Option<uuid::Uuid>,

--- a/apps/libgrader/src/domains/assignments/dto/assignment_dto.rs
+++ b/apps/libgrader/src/domains/assignments/dto/assignment_dto.rs
@@ -1,4 +1,6 @@
-use crate::domains::assignments::domain::model::{Assignment, AssignmentWithAttachmentCount};
+use crate::domains::assignments::domain::model::{
+    Assignment, AssignmentDeadlineType, AssignmentWithAttachmentCount,
+};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use simple_dto_mapper_derive::DtoFrom;
@@ -14,6 +16,7 @@ pub struct AssignmentDto {
     pub description: Option<String>,
     #[serde(with = "crate::common::ts_format::option")]
     pub due_at: Option<DateTime<Utc>>,
+    pub deadline_type: AssignmentDeadlineType,
     pub points: Option<i16>,
 }
 
@@ -24,6 +27,7 @@ pub struct CreateAssignmentDto {
     pub title: String,
     pub description: Option<String>,
     pub due_at: Option<DateTime<Utc>>,
+    pub deadline_type: AssignmentDeadlineType,
     pub modified_by: uuid::Uuid,
     pub points: Option<i16>,
 }
@@ -36,6 +40,7 @@ pub struct UpdateAssignmentDto {
     pub title: String,
     pub description: Option<String>,
     pub due_at: Option<DateTime<Utc>>,
+    pub deadline_type: AssignmentDeadlineType,
     pub modified_by: uuid::Uuid,
     pub points: Option<i16>,
 }
@@ -49,6 +54,7 @@ pub struct AssignmentWithAttachmentCountDto {
     pub description: Option<String>,
     #[serde(with = "crate::common::ts_format::option")]
     pub due_at: Option<DateTime<Utc>>,
+    pub deadline_type: AssignmentDeadlineType,
     pub points: Option<i16>,
     pub attachment_count: i32,
 }

--- a/apps/libgrader/src/domains/assignments/infra/impl_repository.rs
+++ b/apps/libgrader/src/domains/assignments/infra/impl_repository.rs
@@ -21,6 +21,7 @@ const FIND_ALL_ASSIGNMENTS_QUERY: &str = r#"
         a.title,
         a.description,
         a.due_at,
+        a.deadline_type,
         a.points,
         a.created_by,
         a.created_at,
@@ -37,6 +38,7 @@ SELECT
     a.title,
     a.description,
     a.due_at,
+    a.deadline_type,
     a.points,
     a.created_by,
     a.created_at,
@@ -52,6 +54,7 @@ SELECT
     a.title,
     a.description,
     a.due_at,
+    a.deadline_type,
     a.points,
     a.created_by,
     a.created_at,
@@ -90,9 +93,18 @@ const LIST_STUDENT_SUBMISSION_HISTORY_QUERY: &str = r#"
         uf.file_size,
         aa.created_by AS submitted_by,
         aa.created_at AS submitted_at,
+        a.deadline_type,
+        CASE
+            WHEN a.deadline_type = 'soft_deadline'
+                AND a.due_at IS NOT NULL
+                AND aa.created_at > a.due_at
+            THEN TRUE
+            ELSE FALSE
+        END AS is_late,
         gj.status AS grading_status,
         gj.completed_at AS grading_completed_at
     FROM assignment_attachments aa
+    INNER JOIN assignments a ON a.id = aa.assignment_id
     INNER JOIN uploaded_files uf ON uf.id = aa.file_id
     LEFT JOIN grading_jobs gj
         ON gj.assignment_id = aa.assignment_id
@@ -109,6 +121,7 @@ const LIST_ASSIGNMENTS_WITH_ATTACHMENT_COUNT_QUERY: &str = r#"
       a.title,
       a.description,
       a.due_at,
+      a.deadline_type,
       a.points,
       a.created_by,
       a.created_at,
@@ -119,7 +132,7 @@ const LIST_ASSIGNMENTS_WITH_ATTACHMENT_COUNT_QUERY: &str = r#"
     LEFT JOIN assignment_attachments aa ON aa.assignment_id = a.id
     WHERE a.class_id = $1
     GROUP BY
-      a.id, a.class_id, a.title, a.description, a.due_at,
+      a.id, a.class_id, a.title, a.description, a.due_at, a.deadline_type,
       a.created_by, a.created_at, a.modified_by, a.modified_at
     ORDER BY a.due_at NULLS LAST, a.created_at DESC;
 "#;
@@ -258,8 +271,10 @@ impl AssignmentRepositoryTrait for AssignmentRepository {
 
         sqlx::query(
             r#"
-                INSERT INTO assignments (id, class_id, title, description, due_at, points, created_by, modified_by)
-                VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+                INSERT INTO assignments (
+                    id, class_id, title, description, due_at, deadline_type, points, created_by, modified_by
+                )
+                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
                 "#,
         )
             .bind(id)
@@ -267,6 +282,7 @@ impl AssignmentRepositoryTrait for AssignmentRepository {
             .bind(assignment.title.clone())
             .bind(assignment.description.clone())
             .bind(assignment.due_at)
+            .bind(assignment.deadline_type)
             .bind(assignment.points)
             .bind(assignment.modified_by)
             .bind(assignment.modified_by)
@@ -296,16 +312,18 @@ impl AssignmentRepositoryTrait for AssignmentRepository {
                     title = $2,
                     description = $3,
                     due_at = $4,
-                    points = $5,
-                    modified_by = $6,
+                    deadline_type = $5,
+                    points = $6,
+                    modified_by = $7,
                     modified_at = NOW()
-                WHERE id = $7
+                WHERE id = $8
                 "#,
             )
             .bind(assignment.class_id)
             .bind(assignment.title.clone())
             .bind(assignment.description.clone())
             .bind(assignment.due_at)
+            .bind(assignment.deadline_type)
             .bind(assignment.points)
             .bind(assignment.modified_by)
             .bind(id)

--- a/apps/libgrader/src/domains/classes/domain/model.rs
+++ b/apps/libgrader/src/domains/classes/domain/model.rs
@@ -2,6 +2,8 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use sqlx::FromRow;
 
+use crate::domains::assignments::AssignmentDeadlineType;
+
 #[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
 pub struct Class {
     pub id: uuid::Uuid,
@@ -24,5 +26,6 @@ pub struct ClassesWithAssignments {
     pub assignment_title: Option<String>,
     pub assignment_description: Option<String>,
     pub due_at: Option<DateTime<Utc>>,
+    pub deadline_type: Option<AssignmentDeadlineType>,
     pub points: Option<i16>,
 }

--- a/apps/libgrader/src/domains/classes/dto/class_dto.rs
+++ b/apps/libgrader/src/domains/classes/dto/class_dto.rs
@@ -4,6 +4,7 @@ use simple_dto_mapper_derive::DtoFrom;
 use utoipa::ToSchema;
 use validator::Validate;
 
+use crate::domains::assignments::AssignmentDeadlineType;
 use crate::domains::classes::domain::model::{Class, ClassesWithAssignments};
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema, DtoFrom)]
@@ -50,5 +51,6 @@ pub struct ClassesWithAssignmentsDto {
     pub assignment_description: Option<String>,
     #[serde(with = "crate::common::ts_format::option")]
     pub due_at: Option<DateTime<Utc>>,
+    pub deadline_type: Option<AssignmentDeadlineType>,
     pub points: Option<i16>,
 }

--- a/apps/libgrader/src/domains/classes/infra/impl_repository.rs
+++ b/apps/libgrader/src/domains/classes/infra/impl_repository.rs
@@ -32,6 +32,7 @@ pub const LIST_CLASSES_WITH_ASSIGNMENTS: &str = r#"
            a.title as assignment_title,
            a.description as assignment_description,
            a.due_at,
+           a.deadline_type,
            a.points
     FROM classes c
     LEFT JOIN assignments a on c.id = a.class_id

--- a/apps/web/db-seed/seed.sql
+++ b/apps/web/db-seed/seed.sql
@@ -101,13 +101,14 @@ VALUES ('30000000-0000-0000-0000-000000000001', '20000000-0000-0000-0000-0000000
         '00000000-0000-0000-0000-000000000004', 'student', NOW(), NOW());
 
 -- Assignments
-INSERT INTO assignments (id, class_id, title, description, due_at, points, created_by, created_at, modified_by,
-                         modified_at)
+INSERT INTO assignments (id, class_id, title, description, due_at, deadline_type, points, created_by, created_at,
+                         modified_by, modified_at)
 VALUES ('40000000-0000-0000-0000-000000000001',
         '20000000-0000-0000-0000-000000000001',
         'Ownership and Borrowing',
         'Practice references, lifetimes, and ownership transfer.',
         NOW() + INTERVAL '7 days',
+        'soft_deadline',
         100,
         '00000000-0000-0000-0000-000000000002',
         NOW(),
@@ -118,6 +119,7 @@ VALUES ('40000000-0000-0000-0000-000000000001',
         'Error Handling',
         'Build a CLI with robust Result-based error handling.',
         NOW() + INTERVAL '14 days',
+        'soft_deadline',
         50,
         '00000000-0000-0000-0000-000000000002',
         NOW(),
@@ -128,6 +130,7 @@ VALUES ('40000000-0000-0000-0000-000000000001',
         'HTTP Middleware',
         'Implement request logging and auth middleware in Axum.',
         NOW() + INTERVAL '10 days',
+        'soft_deadline',
         100,
         '00000000-0000-0000-0000-000000000002',
         NOW(),

--- a/apps/web/migrations/20260316190000_add_assignment_deadline_type.sql
+++ b/apps/web/migrations/20260316190000_add_assignment_deadline_type.sql
@@ -1,0 +1,4 @@
+CREATE TYPE assignment_deadline_type_enum AS ENUM ('hard_cutoff', 'soft_deadline');
+
+ALTER TABLE assignments
+    ADD COLUMN deadline_type assignment_deadline_type_enum NOT NULL DEFAULT 'soft_deadline';

--- a/apps/web/src/web/instructors.rs
+++ b/apps/web/src/web/instructors.rs
@@ -15,8 +15,8 @@ use uuid::Uuid;
 use crate::common::error::AppError;
 use crate::common::jwt::Claims;
 use crate::common::multipart_helper::parse_multipart_to_maps;
-use crate::domains::assignments::AssignmentServiceTrait;
 use crate::domains::assignments::dto::assignment_dto::UpdateAssignmentDto;
+use crate::domains::assignments::{AssignmentDeadlineType, AssignmentServiceTrait};
 use crate::domains::class_memberships::{
     ClassMembershipRole, ClassMembershipServiceTrait,
     dto::class_membership_dto::CreateClassMembershipDto,
@@ -60,8 +60,17 @@ struct InstructorStudentSubmissionRow {
     content_type: String,
     file_size: i64,
     submitted_at: DateTime<Utc>,
+    is_late: bool,
     grading_status: String,
     grading_completed_at: Option<DateTime<Utc>>,
+}
+
+fn parse_deadline_type(value: &str) -> Result<AssignmentDeadlineType, AppError> {
+    match value {
+        "hard_cutoff" => Ok(AssignmentDeadlineType::HardCutoff),
+        "soft_deadline" => Ok(AssignmentDeadlineType::SoftDeadline),
+        _ => Err(AppError::ValidationError("Invalid deadline type".into())),
+    }
 }
 
 pub async fn instructors_page(
@@ -572,6 +581,9 @@ pub async fn edit_assignment_page(
             form_action => format!("/ui/instructors/assignments/{assignment_id}/edit"),
             title_value => assignment.title.clone(),
             description_value => assignment.description.clone(),
+            due_at_value => assignment.due_at,
+            deadline_type_value => assignment.deadline_type,
+            points_value => assignment.points,
             authenticity_token => authenticity_token,
         },
     )?;
@@ -629,6 +641,7 @@ pub async fn instructor_student_submission_history_page(
             content_type: submission.content_type,
             file_size: submission.file_size,
             submitted_at: submission.submitted_at,
+            is_late: submission.is_late,
             grading_status: submission
                 .grading_status
                 .unwrap_or_else(|| "not_queued".to_string()),
@@ -684,8 +697,8 @@ pub async fn edit_assignment_submit(
     let title = form.title.trim().to_string();
     let description_value = form.description.as_deref().unwrap_or("").trim().to_string();
     let points = form.points;
-
     let due_at_value = form.due_at.as_deref().unwrap_or("").trim().to_string();
+    let deadline_type_value = form.deadline_type.trim().to_string();
 
     if title.is_empty() {
         let html = render_template(
@@ -702,6 +715,8 @@ pub async fn edit_assignment_submit(
                 title_value => title,
                 description_value => description_value,
                 due_at_value => due_at_value,
+                deadline_type_value => deadline_type_value,
+                points_value => points,
                 authenticity_token => token.authenticity_token().unwrap_or_default(),
             },
         )?;
@@ -726,6 +741,7 @@ pub async fn edit_assignment_submit(
                 .map_err(|_| AppError::ValidationError("Invalid due date format".into()))?;
             Some(DateTime::<Utc>::from_naive_utc_and_offset(parsed, Utc))
         },
+        deadline_type: parse_deadline_type(&deadline_type_value)?,
         points: if points.is_negative() {
             Some(0)
         } else {
@@ -754,7 +770,9 @@ pub async fn edit_assignment_submit(
                     form_action => format!("/ui/instructors/assignments/{assignment_id}/edit"),
                     title_value => "",
                     due_at_value => due_at_value,
+                    deadline_type_value => deadline_type_value,
                     description_value => description_value,
+                    points_value => points,
                     authenticity_token => token.authenticity_token().unwrap_or_default(),
                 },
             )?;
@@ -870,6 +888,7 @@ pub struct EditAssignmentForm {
     title: String,
     description: Option<String>,
     due_at: Option<String>,
+    deadline_type: String,
     authenticity_token: String,
     points: i16,
 }

--- a/apps/web/src/web/mod.rs
+++ b/apps/web/src/web/mod.rs
@@ -119,6 +119,7 @@ fn register_filters(env: &mut Environment<'static>) {
     env.add_filter("format_date", format_date);
     env.add_filter("format_datetime_local", format_datetime_local);
     env.add_filter("format_datetime_display", format_datetime_display);
+    env.add_filter("format_deadline_type", format_deadline_type);
 }
 
 fn format_date(value: Value) -> String {
@@ -172,6 +173,23 @@ fn format_datetime_display(value: Value) -> String {
             .format("%b %-d, %Y %H:%M UTC")
             .to_string(),
         Err(_) => raw,
+    }
+}
+
+fn format_deadline_type(value: Value) -> String {
+    if value.is_undefined() {
+        return "".to_string();
+    }
+
+    let raw = value.to_string();
+    if raw.is_empty() || raw == "none" || raw == "null" {
+        return "".to_string();
+    }
+
+    match raw.trim_matches('"') {
+        "hard_cutoff" => "Hard cutoff".to_string(),
+        "soft_deadline" => "Soft deadline".to_string(),
+        other => other.replace('_', " "),
     }
 }
 

--- a/apps/web/src/web/students.rs
+++ b/apps/web/src/web/students.rs
@@ -1,6 +1,7 @@
 use crate::common::error::AppError;
 use crate::common::jwt::Claims;
 use crate::common::multipart_helper::parse_multipart_to_maps;
+use crate::domains::assignments::AssignmentDeadlineType;
 use crate::domains::assignments::AssignmentServiceTrait;
 use crate::domains::class_memberships::ClassMembershipServiceTrait;
 use crate::domains::classes::ClassServiceTrait;
@@ -86,6 +87,7 @@ struct StudentAssignmentRow {
     title: String,
     description: Option<String>,
     due_at: Option<chrono::DateTime<chrono::Utc>>,
+    deadline_type: AssignmentDeadlineType,
     points: Option<i16>,
 }
 
@@ -117,6 +119,7 @@ pub async fn students_assignments_page(
                 title: assignment.title,
                 description: assignment.description,
                 due_at: assignment.due_at,
+                deadline_type: assignment.deadline_type,
                 points: assignment.points,
             });
         }
@@ -151,6 +154,7 @@ struct StudentSubmissionAttachment {
     content_type: String,
     file_size: i64,
     created_at: chrono::DateTime<chrono::Utc>,
+    is_late: bool,
 }
 
 async fn get_student_assignment_context(
@@ -195,6 +199,12 @@ async fn get_student_assignment_context(
             content_type: a.content_type,
             file_size: a.file_size,
             created_at: a.created_at,
+            is_late: matches!(
+                assignment.deadline_type,
+                AssignmentDeadlineType::SoftDeadline
+            ) && assignment
+                .due_at
+                .is_some_and(|due_at| a.created_at > due_at),
         })
         .collect::<Vec<_>>();
 
@@ -297,6 +307,24 @@ pub async fn submit_student_assignment(
                 submission_files => submission_files,
                 submitted => false,
                 error => "Add code in the textarea or attach at least one file before submitting.",
+                authenticity_token => token.authenticity_token().unwrap_or_default(),
+            },
+        )?;
+        return Ok((StatusCode::BAD_REQUEST, token, Html(html)).into_response());
+    }
+
+    if matches!(assignment.deadline_type, AssignmentDeadlineType::HardCutoff)
+        && assignment.due_at.is_some_and(|due_at| Utc::now() > due_at)
+    {
+        let html = render_template(
+            "assignments/student_detail.html",
+            context! {
+                title => format!("Assignment: {}", assignment.title),
+                class => class,
+                assignment => assignment,
+                submission_files => submission_files,
+                submitted => false,
+                error => "This assignment is closed. The hard cutoff deadline has passed.",
                 authenticity_token => token.authenticity_token().unwrap_or_default(),
             },
         )?;

--- a/apps/web/templates/assignments/create_assignment.html
+++ b/apps/web/templates/assignments/create_assignment.html
@@ -48,6 +48,23 @@
                    class="auth-input"/>
         </div>
 
+        <div class="space-y-2">
+            <label for="deadline_type" class="text-sm font-medium text-slate-700">Deadline Type</label>
+            <select id="deadline_type" name="deadline_type" class="auth-input" required>
+                <option value="hard_cutoff"
+                        {% if (assignment and assignment.deadline_type == "hard_cutoff") or (not assignment and deadline_type_value == "hard_cutoff") %}selected{% endif %}>
+                    Hard cutoff
+                </option>
+                <option value="soft_deadline"
+                        {% if (assignment and assignment.deadline_type == "soft_deadline") or (not assignment and deadline_type_value == "soft_deadline") %}selected{% endif %}>
+                    Soft deadline
+                </option>
+            </select>
+            <p class="text-xs text-slate-500">
+                Hard cutoff blocks submissions after the due time. Soft deadline allows submissions but marks them late.
+            </p>
+        </div>
+
         <div class="flex gap-2">
             <button type="submit"
                     class="btn-primary">

--- a/apps/web/templates/assignments/instructor_submission_history.html
+++ b/apps/web/templates/assignments/instructor_submission_history.html
@@ -44,6 +44,9 @@
                 <td class="px-4 py-2 text-slate-700">{{ submission.file_size }} bytes</td>
                 <td class="px-4 py-2 text-slate-700 uppercase">
                     {{ submission.grading_status|replace("_", " ") }}
+                    {% if submission.is_late %}
+                    <div class="text-xs normal-case text-amber-700 mt-1">Late submission</div>
+                    {% endif %}
                     {% if submission.grading_completed_at %}
                     <div class="text-xs normal-case text-slate-500">
                         Completed {{ submission.grading_completed_at|format_datetime_display }}

--- a/apps/web/templates/assignments/partials/_row.html
+++ b/apps/web/templates/assignments/partials/_row.html
@@ -4,7 +4,8 @@
     <td class="px-4 py-2 text-slate-700">{{ assignment.assignment_description or "-" }}</td>
     <td class="px-4 py-2 text-slate-700">
         {% if assignment.due_at %}
-        {{ assignment.due_at|format_date }}
+        {{ assignment.due_at|format_datetime_display }}
+        <div class="text-xs text-slate-500 mt-1">{{ assignment.deadline_type|format_deadline_type }}</div>
         {% else %}
         -
         {% endif %}

--- a/apps/web/templates/assignments/student_detail.html
+++ b/apps/web/templates/assignments/student_detail.html
@@ -38,8 +38,13 @@
     <dl class="grid gap-3 md:grid-cols-3">
         <div>
             <dt class="text-xs uppercase tracking-wide text-slate-500">Due Date</dt>
-            <dd class="text-slate-800">{% if assignment.due_at %}{{ assignment.due_at|format_date }}{% else %}-{% endif
-                %}
+            <dd class="text-slate-800">
+                {% if assignment.due_at %}
+                {{ assignment.due_at|format_datetime_display }}
+                <div class="text-xs text-slate-500 mt-1">{{ assignment.deadline_type|format_deadline_type }}</div>
+                {% else %}
+                -
+                {% endif %}
             </dd>
         </div>
         <div>
@@ -124,6 +129,9 @@
                 {{ file.origin_file_name }}
             </a>
             <span class="text-slate-500">({{ file.content_type }}, {{ file.file_size }} bytes)</span>
+            {% if file.is_late %}
+            <div class="text-xs text-amber-700 mt-1">Late submission</div>
+            {% endif %}
         </li>
         {% endfor %}
     </ul>

--- a/apps/web/templates/assignments/student_index.html
+++ b/apps/web/templates/assignments/student_index.html
@@ -36,7 +36,8 @@
                 <td class="px-4 py-2 text-slate-700">{{ assignment.description or "-" }}</td>
                 <td class="px-4 py-2 text-slate-700">
                     {% if assignment.due_at %}
-                    {{ assignment.due_at|format_date }}
+                    {{ assignment.due_at|format_datetime_display }}
+                    <div class="text-xs text-slate-500 mt-1">{{ assignment.deadline_type|format_deadline_type }}</div>
                     {% else %}
                     -
                     {% endif %}

--- a/apps/web/templates/classes/class_detail.html
+++ b/apps/web/templates/classes/class_detail.html
@@ -101,7 +101,8 @@
                 <td class="px-4 py-2 text-slate-700">{{ assignment.description or "-" }}</td>
                 <td class="px-4 py-2 text-slate-700">
                     {% if assignment.due_at %}
-                    {{ assignment.due_at|format_date }}
+                    {{ assignment.due_at|format_datetime_display }}
+                    <div class="text-xs text-slate-500 mt-1">{{ assignment.deadline_type|format_deadline_type }}</div>
                     {% else %}
                     -
                     {% endif %}

--- a/apps/web/tests/domains/assignments/test_assignment_routes.rs
+++ b/apps/web/tests/domains/assignments/test_assignment_routes.rs
@@ -12,7 +12,8 @@ use grade_o_matic_web::domains::assignments::dto::assignment_dto::{
     AssignmentDto, AssignmentWithAttachmentCountDto, CreateAssignmentDto, UpdateAssignmentDto,
 };
 use grade_o_matic_web::domains::assignments::{
-    AssignmentAttachment, AssignmentServiceTrait, StudentAssignmentSubmission, assignment_routes,
+    AssignmentAttachment, AssignmentDeadlineType, AssignmentServiceTrait,
+    StudentAssignmentSubmission, assignment_routes,
 };
 use sqlx::PgPool;
 use std::collections::HashMap;
@@ -48,6 +49,7 @@ impl FakeAssignmentService {
             title: "Seed Assignment".to_string(),
             description: Some("This is a seed assignment for testing purposes.".to_string()),
             due_at: Some(Utc::now()),
+            deadline_type: AssignmentDeadlineType::SoftDeadline,
             points: Some(100),
         };
 
@@ -94,6 +96,7 @@ impl AssignmentServiceTrait for FakeAssignmentService {
                 title: assignment.title,
                 description: assignment.description,
                 due_at: assignment.due_at,
+                deadline_type: assignment.deadline_type,
                 points: assignment.points,
                 attachment_count: 0,
             })
@@ -145,6 +148,7 @@ impl AssignmentServiceTrait for FakeAssignmentService {
             title: assignment.title,
             description: assignment.description,
             due_at: assignment.due_at,
+            deadline_type: assignment.deadline_type,
             points: None,
         };
 
@@ -163,6 +167,7 @@ impl AssignmentServiceTrait for FakeAssignmentService {
         assignment.title = payload.title.clone();
         assignment.description = payload.description.clone();
         assignment.due_at = payload.due_at;
+        assignment.deadline_type = payload.deadline_type;
 
         Ok(assignment.clone())
     }
@@ -229,6 +234,7 @@ async fn create_assignment(app: &Router) -> (CreateAssignmentDto, AssignmentDto)
         title: "Test Assignment".to_string(),
         description: None,
         due_at: Some(Utc::now()),
+        deadline_type: AssignmentDeadlineType::SoftDeadline,
         points: Some(100),
         modified_by: TEST_USER_ID,
     };
@@ -289,6 +295,7 @@ async fn test_create_assignment() {
     assert_eq!(assignment_dto.title, payload.title);
     assert_eq!(assignment_dto.description, payload.description);
     assert_eq!(assignment_dto.due_at, payload.due_at);
+    assert_eq!(assignment_dto.deadline_type, payload.deadline_type);
 }
 
 #[tokio::test]
@@ -302,6 +309,7 @@ async fn test_update_assignment() {
         title: "Updated Title".to_string(),
         description: Some("Updated Description".to_string()),
         due_at: Some(Utc::now()),
+        deadline_type: AssignmentDeadlineType::HardCutoff,
         points: Some(100),
         modified_by: Default::default(),
     };
@@ -317,6 +325,7 @@ async fn test_update_assignment() {
     assert_eq!(assignment_dto.title, payload.title);
     assert_eq!(assignment_dto.description, payload.description);
     assert_eq!(assignment_dto.due_at, payload.due_at);
+    assert_eq!(assignment_dto.deadline_type, payload.deadline_type);
 }
 
 #[tokio::test]

--- a/apps/web/tests/domains/assignments/test_assignments_service.rs
+++ b/apps/web/tests/domains/assignments/test_assignments_service.rs
@@ -5,9 +5,9 @@ use chrono::Utc;
 use grade_o_matic_web::{
     common::error::AppError,
     domains::assignments::{
-        Assignment, AssignmentAttachment, AssignmentRepositoryTrait, AssignmentService,
-        AssignmentServiceTrait, AssignmentWithAttachmentCount, StudentAssignmentSubmission,
-        create_assignment_service,
+        Assignment, AssignmentAttachment, AssignmentDeadlineType, AssignmentRepositoryTrait,
+        AssignmentService, AssignmentServiceTrait, AssignmentWithAttachmentCount,
+        StudentAssignmentSubmission, create_assignment_service,
         dto::assignment_dto::{CreateAssignmentDto, UpdateAssignmentDto},
     },
 };
@@ -83,6 +83,7 @@ impl AssignmentRepositoryTrait for FakeAssignmentRepository {
                 title: assignment.title,
                 description: assignment.description,
                 due_at: assignment.due_at,
+                deadline_type: assignment.deadline_type,
                 points: assignment.points,
                 created_by: assignment.created_by,
                 created_at: assignment.created_at,
@@ -157,6 +158,7 @@ impl AssignmentRepositoryTrait for FakeAssignmentRepository {
             title: assignment.title,
             description: assignment.description,
             due_at: assignment.due_at,
+            deadline_type: assignment.deadline_type,
             points: Some(100),
             created_by: Some(assignment.modified_by),
             created_at: Some(now),
@@ -188,6 +190,7 @@ impl AssignmentRepositoryTrait for FakeAssignmentRepository {
         existing.title = assignment.title;
         existing.description = assignment.description;
         existing.due_at = assignment.due_at;
+        existing.deadline_type = assignment.deadline_type;
         existing.modified_by = Some(assignment.modified_by);
         existing.modified_at = Some(Utc::now());
 
@@ -214,6 +217,7 @@ fn seed_assignment(id: Uuid) -> Assignment {
         title: "assignment-1".to_string(),
         description: Some("description".to_string()),
         due_at: Some(Utc::now()),
+        deadline_type: AssignmentDeadlineType::SoftDeadline,
         points: Some(100),
         created_by: Some(user_id),
         created_at: Some(Utc::now()),
@@ -266,6 +270,7 @@ async fn create_persists_and_returns_assignment() {
         title: "new assignment".to_string(),
         description: Some("desc".to_string()),
         due_at: Some(Utc::now()),
+        deadline_type: AssignmentDeadlineType::SoftDeadline,
         points: Some(100),
         modified_by,
     };
@@ -287,6 +292,7 @@ async fn update_returns_not_found_error_when_missing() {
         title: "updated".to_string(),
         description: Some("updated".to_string()),
         due_at: Some(Utc::now()),
+        deadline_type: AssignmentDeadlineType::SoftDeadline,
         points: Some(100),
         modified_by: Uuid::new_v4(),
     };
@@ -456,6 +462,7 @@ async fn db_create_update_and_delete_assignment_happy_path() {
             title: "Project 1".to_string(),
             description: Some("Implement parser".to_string()),
             due_at: Some(Utc::now() + chrono::Duration::days(7)),
+            deadline_type: AssignmentDeadlineType::SoftDeadline,
             points: Some(100),
             modified_by: instructor_id,
         })
@@ -471,6 +478,7 @@ async fn db_create_update_and_delete_assignment_happy_path() {
             title: "Project 1 Revised".to_string(),
             description: Some("Implement parser + tests".to_string()),
             due_at: Some(Utc::now() + chrono::Duration::days(10)),
+            deadline_type: AssignmentDeadlineType::HardCutoff,
             points: Some(120),
             modified_by: instructor_id,
         })
@@ -506,6 +514,7 @@ async fn db_list_by_class_with_attachment_count_filters_and_counts() {
             title: "Counted Assignment".to_string(),
             description: Some("with attachments".to_string()),
             due_at: None,
+            deadline_type: AssignmentDeadlineType::SoftDeadline,
             points: Some(50),
             modified_by: instructor_id,
         })
@@ -518,6 +527,7 @@ async fn db_list_by_class_with_attachment_count_filters_and_counts() {
             title: "Other Assignment".to_string(),
             description: Some("different class".to_string()),
             due_at: None,
+            deadline_type: AssignmentDeadlineType::SoftDeadline,
             points: Some(10),
             modified_by: instructor_id,
         })
@@ -567,6 +577,7 @@ async fn db_attach_list_and_remove_file_happy_and_edge_paths() {
             title: "Upload Work".to_string(),
             description: Some("submit assets".to_string()),
             due_at: None,
+            deadline_type: AssignmentDeadlineType::SoftDeadline,
             points: Some(25),
             modified_by: instructor_id,
         })
@@ -621,6 +632,7 @@ async fn db_list_student_submission_history_returns_student_attempts_with_status
             title: "History Assignment".to_string(),
             description: Some("multiple attempts".to_string()),
             due_at: None,
+            deadline_type: AssignmentDeadlineType::SoftDeadline,
             points: Some(75),
             modified_by: instructor_id,
         })
@@ -682,6 +694,7 @@ async fn db_update_and_delete_missing_assignment_returns_not_found() {
             title: "missing".to_string(),
             description: Some("missing".to_string()),
             due_at: None,
+            deadline_type: AssignmentDeadlineType::SoftDeadline,
             points: Some(5),
             modified_by: instructor_id,
         })
@@ -769,6 +782,8 @@ async fn list_student_submission_history_returns_rows() {
             file_size: 2048,
             submitted_by: student_id,
             submitted_at: Utc::now(),
+            deadline_type: AssignmentDeadlineType::SoftDeadline,
+            is_late: true,
             grading_status: Some("completed".to_string()),
             grading_completed_at: Some(Utc::now()),
         }],
@@ -875,6 +890,7 @@ async fn create_returns_database_error_or_not_found_for_missing_row() {
             title: "new".to_string(),
             description: None,
             due_at: None,
+            deadline_type: AssignmentDeadlineType::SoftDeadline,
             points: Some(10),
             modified_by: Uuid::new_v4(),
         })
@@ -892,6 +908,7 @@ async fn create_returns_database_error_or_not_found_for_missing_row() {
             title: "new".to_string(),
             description: None,
             due_at: None,
+            deadline_type: AssignmentDeadlineType::SoftDeadline,
             points: Some(10),
             modified_by: Uuid::new_v4(),
         })
@@ -923,6 +940,7 @@ async fn find_update_and_delete_return_database_error_or_not_found_paths() {
                 title: "t".to_string(),
                 description: None,
                 due_at: None,
+                deadline_type: AssignmentDeadlineType::SoftDeadline,
                 points: Some(1),
                 modified_by: Uuid::new_v4(),
             })

--- a/apps/web/tests/domains/auth/test_web_routes_auth.rs
+++ b/apps/web/tests/domains/auth/test_web_routes_auth.rs
@@ -8,12 +8,13 @@ use axum::{
         header::{AUTHORIZATION, CONTENT_TYPE, COOKIE, LOCATION, SET_COOKIE},
     },
 };
-use chrono::Utc;
+use chrono::{Duration, Utc};
 use grade_o_matic_web::{
     common::error::AppError,
     common::jwt::{self, AuthBody, AuthPayload},
     domains::assignments::{
-        AssignmentAttachment, AssignmentServiceTrait, StudentAssignmentSubmission,
+        AssignmentAttachment, AssignmentDeadlineType, AssignmentServiceTrait,
+        StudentAssignmentSubmission,
         dto::assignment_dto::{AssignmentDto, AssignmentWithAttachmentCountDto},
     },
     domains::auth::AuthServiceTrait,
@@ -88,6 +89,10 @@ fn ta_user_id() -> Uuid {
 
 fn student_assignment_id() -> Uuid {
     Uuid::parse_str("dddddddd-dddd-dddd-dddd-dddddddddddd").expect("valid uuid")
+}
+
+fn hard_cutoff_assignment_id() -> Uuid {
+    Uuid::parse_str("dededede-dede-dede-dede-dededededede").expect("valid uuid")
 }
 
 fn second_submission_file_id() -> Uuid {
@@ -306,14 +311,26 @@ impl AssignmentServiceTrait for FakeAssignmentService {
 
     async fn list_by_class(&self, _class_id: Uuid) -> Result<Vec<AssignmentDto>, AppError> {
         if _class_id == enrolled_class_id() {
-            return Ok(vec![AssignmentDto {
-                id: student_assignment_id(),
-                class_id: enrolled_class_id(),
-                title: "Homework 1".to_string(),
-                description: Some("Ownership and borrowing".to_string()),
-                due_at: None,
-                points: Some(100),
-            }]);
+            return Ok(vec![
+                AssignmentDto {
+                    id: student_assignment_id(),
+                    class_id: enrolled_class_id(),
+                    title: "Homework 1".to_string(),
+                    description: Some("Ownership and borrowing".to_string()),
+                    due_at: None,
+                    deadline_type: AssignmentDeadlineType::SoftDeadline,
+                    points: Some(100),
+                },
+                AssignmentDto {
+                    id: hard_cutoff_assignment_id(),
+                    class_id: enrolled_class_id(),
+                    title: "Locked Homework".to_string(),
+                    description: Some("Deadline has passed".to_string()),
+                    due_at: Some(Utc::now() - Duration::minutes(10)),
+                    deadline_type: AssignmentDeadlineType::HardCutoff,
+                    points: Some(50),
+                },
+            ]);
         }
 
         if _class_id == other_class_id() {
@@ -323,6 +340,7 @@ impl AssignmentServiceTrait for FakeAssignmentService {
                 title: "Hidden Homework".to_string(),
                 description: Some("Should never be visible to this student".to_string()),
                 due_at: None,
+                deadline_type: AssignmentDeadlineType::SoftDeadline,
                 points: Some(50),
             }]);
         }
@@ -341,6 +359,7 @@ impl AssignmentServiceTrait for FakeAssignmentService {
                 title: "Midterm Project".to_string(),
                 description: Some("Build a service".to_string()),
                 due_at: None,
+                deadline_type: AssignmentDeadlineType::HardCutoff,
                 points: Some(200),
                 attachment_count: 0,
             }]);
@@ -386,6 +405,8 @@ impl AssignmentServiceTrait for FakeAssignmentService {
                     file_size: 2048,
                     submitted_by: enrolled_student_id(),
                     submitted_at: Utc::now(),
+                    deadline_type: AssignmentDeadlineType::SoftDeadline,
+                    is_late: true,
                     grading_status: Some("completed".to_string()),
                     grading_completed_at: Some(Utc::now()),
                 },
@@ -400,6 +421,8 @@ impl AssignmentServiceTrait for FakeAssignmentService {
                     file_size: 1024,
                     submitted_by: enrolled_student_id(),
                     submitted_at: Utc::now(),
+                    deadline_type: AssignmentDeadlineType::SoftDeadline,
+                    is_late: false,
                     grading_status: Some("failed".to_string()),
                     grading_completed_at: None,
                 },
@@ -430,7 +453,19 @@ impl AssignmentServiceTrait for FakeAssignmentService {
                 title: "Homework 1".to_string(),
                 description: Some("Ownership and borrowing".to_string()),
                 due_at: None,
+                deadline_type: AssignmentDeadlineType::SoftDeadline,
                 points: Some(100),
+            }));
+        }
+        if _id == hard_cutoff_assignment_id() {
+            return Ok(Some(AssignmentDto {
+                id: hard_cutoff_assignment_id(),
+                class_id: enrolled_class_id(),
+                title: "Locked Homework".to_string(),
+                description: Some("Deadline has passed".to_string()),
+                due_at: Some(Utc::now() - Duration::minutes(10)),
+                deadline_type: AssignmentDeadlineType::HardCutoff,
+                points: Some(50),
             }));
         }
         if _id == instructor_assignment_id() {
@@ -440,6 +475,7 @@ impl AssignmentServiceTrait for FakeAssignmentService {
                 title: "Midterm Project".to_string(),
                 description: Some("Build a service".to_string()),
                 due_at: None,
+                deadline_type: AssignmentDeadlineType::HardCutoff,
                 points: Some(200),
             }));
         }
@@ -463,6 +499,7 @@ impl AssignmentServiceTrait for FakeAssignmentService {
             title: _assignment.title,
             description: _assignment.description,
             due_at: _assignment.due_at,
+            deadline_type: _assignment.deadline_type,
             points: _assignment.points,
         })
     }
@@ -576,6 +613,7 @@ impl ClassServiceTrait for FakeClassService {
                     assignment_title: Some("Midterm Project".to_string()),
                     assignment_description: Some("Build a service".to_string()),
                     due_at: None,
+                    deadline_type: Some(AssignmentDeadlineType::HardCutoff),
                     points: Some(200),
                 },
             ]);
@@ -1465,7 +1503,7 @@ async fn edit_assignment_submit_happy_path_redirects_to_class() {
         .expect("token should be created");
 
     let body = format!(
-        "title=Updated%20Project&description=Updated%20desc&due_at=2026-03-31T23:59&points=123&authenticity_token={encoded_token}"
+        "title=Updated%20Project&description=Updated%20desc&due_at=2026-03-31T23:59&deadline_type=hard_cutoff&points=123&authenticity_token={encoded_token}"
     );
     let req = Request::builder()
         .method(Method::POST)
@@ -1498,7 +1536,7 @@ async fn edit_assignment_submit_rejects_invalid_due_date() {
         .expect("token should be created");
 
     let body = format!(
-        "title=Updated%20Project&description=Updated%20desc&due_at=bad-date&points=123&authenticity_token={encoded_token}"
+        "title=Updated%20Project&description=Updated%20desc&due_at=bad-date&deadline_type=soft_deadline&points=123&authenticity_token={encoded_token}"
     );
     let req = Request::builder()
         .method(Method::POST)
@@ -1511,6 +1549,43 @@ async fn edit_assignment_submit_rejects_invalid_due_date() {
 
     let response = app.oneshot(req).await.expect("response should return");
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn students_assignment_submit_rejects_past_hard_cutoff() {
+    ensure_jwt_env();
+    let app = create_test_router();
+    let (csrf_cookie, authenticity_token) = get_csrf_cookie_and_token(&app).await;
+
+    let token = jwt::make_jwt_token(&enrolled_student_id(), UserRole::Student)
+        .expect("token should be created");
+
+    let boundary = "X-BOUNDARY-HARD-CUTOFF";
+    let body = build_multipart_form(
+        &[
+            ("authenticity_token", &authenticity_token),
+            ("code_submission", "fn main() {}"),
+        ],
+        boundary,
+    );
+
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri("/ui/students/assignments/dededede-dede-dede-dede-dededededede/submit")
+        .header(AUTHORIZATION, format!("Bearer {token}"))
+        .header(COOKIE, csrf_cookie)
+        .header(
+            CONTENT_TYPE,
+            format!("multipart/form-data; boundary={boundary}"),
+        )
+        .body(Body::from(body))
+        .expect("request should build");
+
+    let response = app.oneshot(req).await.expect("response should return");
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+    let html = body_to_string(response.into_body()).await;
+    assert!(html.contains("hard cutoff deadline has passed"));
 }
 
 #[tokio::test]

--- a/apps/web/tests/domains/classes/test_classes_service.rs
+++ b/apps/web/tests/domains/classes/test_classes_service.rs
@@ -4,6 +4,7 @@ use async_trait::async_trait;
 use chrono::Utc;
 use grade_o_matic_web::{
     common::error::AppError,
+    domains::assignments::AssignmentDeadlineType,
     domains::classes::{
         Class, ClassRepositoryTrait, ClassService, ClassServiceTrait, ClassesWithAssignments,
         create_class_service,
@@ -249,6 +250,7 @@ async fn list_classes_with_assignments_returns_rows() {
             assignment_title: Some("Homework 1".to_string()),
             assignment_description: Some("Graph traversals".to_string()),
             due_at: None,
+            deadline_type: Some(AssignmentDeadlineType::SoftDeadline),
             points: Some(10),
         }],
         ..Default::default()


### PR DESCRIPTION
  Resolves #25

## Overview
Implements instructor-configurable assignment deadline types. Instructors can now set a deadline as either a hard cutoff or a soft deadline, and the selected deadline behavior is reflected anywhere assignment due information is shown.

## Details
This PR adds an `assignment_deadline_type_enum` to persisted assignment data and threads the new field through the assignment and class DTOs, repository queries, and web views.

It updates instructor assignment editing so the form includes a required deadline type selector alongside the due date/time input.

It updates assignment displays for instructors and students to show the full due timestamp together with the deadline type.

It enforces deadline behavior for student submissions:
- Hard cutoff assignments reject submissions after the due timestamp.
- Soft deadline assignments still accept submissions after the due timestamp and mark those submissions as late in both student and instructor views.

It also updates seed data and test coverage for the new assignment deadline behavior.

## Changes outside the codebase
This PR adds a database migration:
- Creates `assignment_deadline_type_enum`
- Adds `assignments.deadline_type` with a default of `soft_deadline`

No external service or infrastructure changes were required.

## Additional information
The implementation keeps the submission enforcement in the student web submission path, which is currently the main behavior boundary for this feature.

Verification completed:
- `cargo test`

### Checklist

- [x] I have run this code in development, and it appears to resolve the stated issue.
- [ ] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval.
- [x] My pull request represents one logical piece of work.
- [x] My commits are related to the pull request and look clean.
- [x] I have added appropriate tests and documentation to any new models.
- [ ] I have updated the README file if appropriate.