### PR TITLE
Resolve #26: add assignment extensions for individual students

### DIFF
--- a/apps/libgrader/src/domains/assignments.rs
+++ b/apps/libgrader/src/domains/assignments.rs
@@ -25,7 +25,7 @@ mod infra {
 pub use api::routes::assignment_routes;
 pub use domain::model::{
     Assignment, AssignmentAttachment, AssignmentDeadlineType, AssignmentWithAttachmentCount,
-    StudentAssignmentSubmission,
+    StudentAssignmentExtension, StudentAssignmentSubmission,
 };
 pub use domain::repository::AssignmentRepositoryTrait;
 pub use domain::service::AssignmentServiceTrait;

--- a/apps/libgrader/src/domains/assignments/domain/model.rs
+++ b/apps/libgrader/src/domains/assignments/domain/model.rs
@@ -18,6 +18,8 @@ pub struct Assignment {
     pub title: String,
     pub description: Option<String>,
     pub due_at: Option<DateTime<Utc>>,
+    pub extension_due_at: Option<DateTime<Utc>>,
+    pub effective_due_at: Option<DateTime<Utc>>,
     pub deadline_type: AssignmentDeadlineType,
     pub points: Option<i16>,
     pub created_by: Option<uuid::Uuid>,
@@ -57,6 +59,17 @@ pub struct StudentAssignmentSubmission {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+pub struct StudentAssignmentExtension {
+    pub assignment_id: uuid::Uuid,
+    pub student_id: uuid::Uuid,
+    pub due_at: DateTime<Utc>,
+    pub created_by: Option<uuid::Uuid>,
+    pub created_at: DateTime<Utc>,
+    pub modified_by: Option<uuid::Uuid>,
+    pub modified_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
 
 pub struct AssignmentWithAttachmentCount {
     pub id: uuid::Uuid,
@@ -64,6 +77,8 @@ pub struct AssignmentWithAttachmentCount {
     pub title: String,
     pub description: Option<String>,
     pub due_at: Option<DateTime<Utc>>,
+    pub extension_due_at: Option<DateTime<Utc>>,
+    pub effective_due_at: Option<DateTime<Utc>>,
     pub deadline_type: AssignmentDeadlineType,
     pub created_by: Option<uuid::Uuid>,
     pub created_at: Option<DateTime<Utc>>,

--- a/apps/libgrader/src/domains/assignments/domain/repository.rs
+++ b/apps/libgrader/src/domains/assignments/domain/repository.rs
@@ -1,7 +1,10 @@
 use super::model::{
-    Assignment, AssignmentAttachment, AssignmentWithAttachmentCount, StudentAssignmentSubmission,
+    Assignment, AssignmentAttachment, AssignmentWithAttachmentCount, StudentAssignmentExtension,
+    StudentAssignmentSubmission,
 };
-use crate::domains::assignments::dto::assignment_dto::{CreateAssignmentDto, UpdateAssignmentDto};
+use crate::domains::assignments::dto::assignment_dto::{
+    CreateAssignmentDto, UpdateAssignmentDto, UpsertStudentAssignmentExtensionDto,
+};
 use async_trait::async_trait;
 use sqlx::PgPool;
 use uuid::Uuid;
@@ -14,6 +17,11 @@ pub trait AssignmentRepositoryTrait: Send + Sync {
 
     async fn find_all(&self) -> Result<Vec<Assignment>, sqlx::Error>;
     async fn find_by_class_id(&self, class_id: Uuid) -> Result<Vec<Assignment>, sqlx::Error>;
+    async fn find_by_class_id_for_student(
+        &self,
+        class_id: Uuid,
+        student_id: Uuid,
+    ) -> Result<Vec<Assignment>, sqlx::Error>;
 
     async fn find_by_class_id_with_attachment_count(
         &self,
@@ -21,6 +29,11 @@ pub trait AssignmentRepositoryTrait: Send + Sync {
     ) -> Result<Vec<AssignmentWithAttachmentCount>, sqlx::Error>;
 
     async fn find_by_id(&self, id: Uuid) -> Result<Option<Assignment>, sqlx::Error>;
+    async fn find_by_id_for_student(
+        &self,
+        id: Uuid,
+        student_id: Uuid,
+    ) -> Result<Option<Assignment>, sqlx::Error>;
     async fn list_attachments(
         &self,
         assignment_id: Uuid,
@@ -30,6 +43,19 @@ pub trait AssignmentRepositoryTrait: Send + Sync {
         assignment_id: Uuid,
         student_id: Uuid,
     ) -> Result<Vec<StudentAssignmentSubmission>, sqlx::Error>;
+    async fn list_student_extensions(
+        &self,
+        assignment_id: Uuid,
+    ) -> Result<Vec<StudentAssignmentExtension>, sqlx::Error>;
+    async fn upsert_student_extension(
+        &self,
+        extension: UpsertStudentAssignmentExtensionDto,
+    ) -> Result<StudentAssignmentExtension, sqlx::Error>;
+    async fn delete_student_extension(
+        &self,
+        assignment_id: Uuid,
+        student_id: Uuid,
+    ) -> Result<bool, sqlx::Error>;
 
     async fn add_attachment(
         &self,

--- a/apps/libgrader/src/domains/assignments/domain/service.rs
+++ b/apps/libgrader/src/domains/assignments/domain/service.rs
@@ -3,7 +3,8 @@ use crate::domains::assignments::domain::model::{
     AssignmentAttachment, StudentAssignmentSubmission,
 };
 use crate::domains::assignments::dto::assignment_dto::{
-    AssignmentDto, AssignmentWithAttachmentCountDto, CreateAssignmentDto, UpdateAssignmentDto,
+    AssignmentDto, AssignmentWithAttachmentCountDto, CreateAssignmentDto,
+    StudentAssignmentExtensionDto, UpdateAssignmentDto, UpsertStudentAssignmentExtensionDto,
 };
 
 use async_trait::async_trait;
@@ -18,6 +19,11 @@ pub trait AssignmentServiceTrait: Send + Sync {
 
     async fn list(&self) -> Result<Vec<AssignmentDto>, AppError>;
     async fn list_by_class(&self, class_id: uuid::Uuid) -> Result<Vec<AssignmentDto>, AppError>;
+    async fn list_by_class_for_student(
+        &self,
+        class_id: uuid::Uuid,
+        student_id: uuid::Uuid,
+    ) -> Result<Vec<AssignmentDto>, AppError>;
 
     async fn list_by_class_with_attachment_count(
         &self,
@@ -33,6 +39,19 @@ pub trait AssignmentServiceTrait: Send + Sync {
         assignment_id: uuid::Uuid,
         student_id: uuid::Uuid,
     ) -> Result<Vec<StudentAssignmentSubmission>, AppError>;
+    async fn list_student_extensions(
+        &self,
+        assignment_id: uuid::Uuid,
+    ) -> Result<Vec<StudentAssignmentExtensionDto>, AppError>;
+    async fn upsert_student_extension(
+        &self,
+        extension: UpsertStudentAssignmentExtensionDto,
+    ) -> Result<StudentAssignmentExtensionDto, AppError>;
+    async fn delete_student_extension(
+        &self,
+        assignment_id: uuid::Uuid,
+        student_id: uuid::Uuid,
+    ) -> Result<bool, AppError>;
     async fn attach_file(
         &self,
         assignment_id: uuid::Uuid,
@@ -46,6 +65,11 @@ pub trait AssignmentServiceTrait: Send + Sync {
     ) -> Result<bool, AppError>;
 
     async fn find_by_id(&self, id: uuid::Uuid) -> Result<Option<AssignmentDto>, AppError>;
+    async fn find_by_id_for_student(
+        &self,
+        id: uuid::Uuid,
+        student_id: uuid::Uuid,
+    ) -> Result<Option<AssignmentDto>, AppError>;
 
     async fn create(&self, assignment: CreateAssignmentDto) -> Result<AssignmentDto, AppError>;
 

--- a/apps/libgrader/src/domains/assignments/dto/assignment_dto.rs
+++ b/apps/libgrader/src/domains/assignments/dto/assignment_dto.rs
@@ -1,5 +1,5 @@
 use crate::domains::assignments::domain::model::{
-    Assignment, AssignmentDeadlineType, AssignmentWithAttachmentCount,
+    Assignment, AssignmentDeadlineType, AssignmentWithAttachmentCount, StudentAssignmentExtension,
 };
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -16,6 +16,10 @@ pub struct AssignmentDto {
     pub description: Option<String>,
     #[serde(with = "crate::common::ts_format::option")]
     pub due_at: Option<DateTime<Utc>>,
+    #[serde(with = "crate::common::ts_format::option")]
+    pub extension_due_at: Option<DateTime<Utc>>,
+    #[serde(with = "crate::common::ts_format::option")]
+    pub effective_due_at: Option<DateTime<Utc>>,
     pub deadline_type: AssignmentDeadlineType,
     pub points: Option<i16>,
 }
@@ -54,7 +58,28 @@ pub struct AssignmentWithAttachmentCountDto {
     pub description: Option<String>,
     #[serde(with = "crate::common::ts_format::option")]
     pub due_at: Option<DateTime<Utc>>,
+    #[serde(with = "crate::common::ts_format::option")]
+    pub extension_due_at: Option<DateTime<Utc>>,
+    #[serde(with = "crate::common::ts_format::option")]
+    pub effective_due_at: Option<DateTime<Utc>>,
     pub deadline_type: AssignmentDeadlineType,
     pub points: Option<i16>,
     pub attachment_count: i32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, DtoFrom)]
+#[dto(from = StudentAssignmentExtension)]
+pub struct StudentAssignmentExtensionDto {
+    pub assignment_id: uuid::Uuid,
+    pub student_id: uuid::Uuid,
+    #[serde(with = "crate::common::ts_format")]
+    pub due_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, Validate)]
+pub struct UpsertStudentAssignmentExtensionDto {
+    pub assignment_id: uuid::Uuid,
+    pub student_id: uuid::Uuid,
+    pub due_at: DateTime<Utc>,
+    pub modified_by: uuid::Uuid,
 }

--- a/apps/libgrader/src/domains/assignments/infra/impl_repository.rs
+++ b/apps/libgrader/src/domains/assignments/infra/impl_repository.rs
@@ -1,12 +1,15 @@
 use async_trait::async_trait;
 
 use crate::domains::assignments::domain::{
-    model::{Assignment, AssignmentAttachment, StudentAssignmentSubmission},
+    model::{
+        Assignment, AssignmentAttachment, AssignmentWithAttachmentCount,
+        StudentAssignmentExtension, StudentAssignmentSubmission,
+    },
     repository::AssignmentRepositoryTrait,
 };
-
-use crate::domains::assignments::domain::model::AssignmentWithAttachmentCount;
-use crate::domains::assignments::dto::assignment_dto::{CreateAssignmentDto, UpdateAssignmentDto};
+use crate::domains::assignments::dto::assignment_dto::{
+    CreateAssignmentDto, UpdateAssignmentDto, UpsertStudentAssignmentExtensionDto,
+};
 use sqlx::{Error, PgPool};
 use uuid::Uuid;
 
@@ -21,6 +24,8 @@ const FIND_ALL_ASSIGNMENTS_QUERY: &str = r#"
         a.title,
         a.description,
         a.due_at,
+        NULL::timestamptz AS extension_due_at,
+        a.due_at AS effective_due_at,
         a.deadline_type,
         a.points,
         a.created_by,
@@ -29,7 +34,7 @@ const FIND_ALL_ASSIGNMENTS_QUERY: &str = r#"
         a.modified_at
     FROM assignments a
     WHERE 1=1
-    "#;
+"#;
 
 const FIND_ASSIGNMENT_BY_ID_QUERY: &str = r#"
 SELECT
@@ -38,14 +43,39 @@ SELECT
     a.title,
     a.description,
     a.due_at,
+    NULL::timestamptz AS extension_due_at,
+    a.due_at AS effective_due_at,
     a.deadline_type,
     a.points,
     a.created_by,
     a.created_at,
     a.modified_by,
     a.modified_at
-    FROM assignments a
-    WHERE a.id = $1"#;
+FROM assignments a
+WHERE a.id = $1
+"#;
+
+const FIND_ASSIGNMENT_BY_ID_FOR_STUDENT_QUERY: &str = r#"
+SELECT
+    a.id,
+    a.class_id,
+    a.title,
+    a.description,
+    a.due_at,
+    ase.due_at AS extension_due_at,
+    COALESCE(ase.due_at, a.due_at) AS effective_due_at,
+    a.deadline_type,
+    a.points,
+    a.created_by,
+    a.created_at,
+    a.modified_by,
+    a.modified_at
+FROM assignments a
+LEFT JOIN assignment_student_extensions ase
+  ON ase.assignment_id = a.id
+ AND ase.student_id = $2
+WHERE a.id = $1
+"#;
 
 const FIND_ASSIGNMENTS_BY_CLASS_ID_QUERY: &str = r#"
 SELECT
@@ -54,15 +84,40 @@ SELECT
     a.title,
     a.description,
     a.due_at,
+    NULL::timestamptz AS extension_due_at,
+    a.due_at AS effective_due_at,
     a.deadline_type,
     a.points,
     a.created_by,
     a.created_at,
     a.modified_by,
     a.modified_at
-    FROM assignments a
-    WHERE a.class_id = $1
-    ORDER BY a.due_at NULLS LAST, a.created_at DESC
+FROM assignments a
+WHERE a.class_id = $1
+ORDER BY a.due_at NULLS LAST, a.created_at DESC
+"#;
+
+const FIND_ASSIGNMENTS_BY_CLASS_ID_FOR_STUDENT_QUERY: &str = r#"
+SELECT
+    a.id,
+    a.class_id,
+    a.title,
+    a.description,
+    a.due_at,
+    ase.due_at AS extension_due_at,
+    COALESCE(ase.due_at, a.due_at) AS effective_due_at,
+    a.deadline_type,
+    a.points,
+    a.created_by,
+    a.created_at,
+    a.modified_by,
+    a.modified_at
+FROM assignments a
+LEFT JOIN assignment_student_extensions ase
+  ON ase.assignment_id = a.id
+ AND ase.student_id = $2
+WHERE a.class_id = $1
+ORDER BY COALESCE(ase.due_at, a.due_at) NULLS LAST, a.created_at DESC
 "#;
 
 const LIST_ASSIGNMENT_ATTACHMENTS_QUERY: &str = r#"
@@ -96,8 +151,8 @@ const LIST_STUDENT_SUBMISSION_HISTORY_QUERY: &str = r#"
         a.deadline_type,
         CASE
             WHEN a.deadline_type = 'soft_deadline'
-                AND a.due_at IS NOT NULL
-                AND aa.created_at > a.due_at
+                AND COALESCE(ase.due_at, a.due_at) IS NOT NULL
+                AND aa.created_at > COALESCE(ase.due_at, a.due_at)
             THEN TRUE
             ELSE FALSE
         END AS is_late,
@@ -105,6 +160,9 @@ const LIST_STUDENT_SUBMISSION_HISTORY_QUERY: &str = r#"
         gj.completed_at AS grading_completed_at
     FROM assignment_attachments aa
     INNER JOIN assignments a ON a.id = aa.assignment_id
+    LEFT JOIN assignment_student_extensions ase
+      ON ase.assignment_id = aa.assignment_id
+     AND ase.student_id = $2
     INNER JOIN uploaded_files uf ON uf.id = aa.file_id
     LEFT JOIN grading_jobs gj
         ON gj.assignment_id = aa.assignment_id
@@ -121,6 +179,8 @@ const LIST_ASSIGNMENTS_WITH_ATTACHMENT_COUNT_QUERY: &str = r#"
       a.title,
       a.description,
       a.due_at,
+      NULL::timestamptz AS extension_due_at,
+      a.due_at AS effective_due_at,
       a.deadline_type,
       a.points,
       a.created_by,
@@ -134,7 +194,21 @@ const LIST_ASSIGNMENTS_WITH_ATTACHMENT_COUNT_QUERY: &str = r#"
     GROUP BY
       a.id, a.class_id, a.title, a.description, a.due_at, a.deadline_type,
       a.created_by, a.created_at, a.modified_by, a.modified_at
-    ORDER BY a.due_at NULLS LAST, a.created_at DESC;
+    ORDER BY a.due_at NULLS LAST, a.created_at DESC
+"#;
+
+const LIST_STUDENT_EXTENSIONS_QUERY: &str = r#"
+    SELECT
+        assignment_id,
+        student_id,
+        due_at,
+        created_by,
+        created_at,
+        modified_by,
+        modified_at
+    FROM assignment_student_extensions
+    WHERE assignment_id = $1
+    ORDER BY due_at DESC, student_id ASC
 "#;
 
 #[async_trait]
@@ -158,6 +232,20 @@ impl AssignmentRepositoryTrait for AssignmentRepository {
         Ok(assignments)
     }
 
+    async fn find_by_class_id_for_student(
+        &self,
+        class_id: Uuid,
+        student_id: Uuid,
+    ) -> Result<Vec<Assignment>, Error> {
+        let assignments =
+            sqlx::query_as::<_, Assignment>(FIND_ASSIGNMENTS_BY_CLASS_ID_FOR_STUDENT_QUERY)
+                .bind(class_id)
+                .bind(student_id)
+                .fetch_all(&self.pool)
+                .await?;
+        Ok(assignments)
+    }
+
     async fn find_by_class_id_with_attachment_count(
         &self,
         id: Uuid,
@@ -174,6 +262,19 @@ impl AssignmentRepositoryTrait for AssignmentRepository {
     async fn find_by_id(&self, id: Uuid) -> Result<Option<Assignment>, Error> {
         let assignment = sqlx::query_as::<_, Assignment>(FIND_ASSIGNMENT_BY_ID_QUERY)
             .bind(id)
+            .fetch_optional(&self.pool)
+            .await?;
+        Ok(assignment)
+    }
+
+    async fn find_by_id_for_student(
+        &self,
+        id: Uuid,
+        student_id: Uuid,
+    ) -> Result<Option<Assignment>, Error> {
+        let assignment = sqlx::query_as::<_, Assignment>(FIND_ASSIGNMENT_BY_ID_FOR_STUDENT_QUERY)
+            .bind(id)
+            .bind(student_id)
             .fetch_optional(&self.pool)
             .await?;
         Ok(assignment)
@@ -205,6 +306,69 @@ impl AssignmentRepositoryTrait for AssignmentRepository {
         Ok(rows)
     }
 
+    async fn list_student_extensions(
+        &self,
+        assignment_id: Uuid,
+    ) -> Result<Vec<StudentAssignmentExtension>, Error> {
+        let rows = sqlx::query_as::<_, StudentAssignmentExtension>(LIST_STUDENT_EXTENSIONS_QUERY)
+            .bind(assignment_id)
+            .fetch_all(&self.pool)
+            .await?;
+        Ok(rows)
+    }
+
+    async fn upsert_student_extension(
+        &self,
+        extension: UpsertStudentAssignmentExtensionDto,
+    ) -> Result<StudentAssignmentExtension, Error> {
+        let row = sqlx::query_as::<_, StudentAssignmentExtension>(
+            r#"
+                INSERT INTO assignment_student_extensions (
+                    assignment_id, student_id, due_at, created_by, modified_by
+                )
+                VALUES ($1, $2, $3, $4, $4)
+                ON CONFLICT (assignment_id, student_id)
+                DO UPDATE SET
+                    due_at = EXCLUDED.due_at,
+                    modified_by = EXCLUDED.modified_by,
+                    modified_at = NOW()
+                RETURNING
+                    assignment_id,
+                    student_id,
+                    due_at,
+                    created_by,
+                    created_at,
+                    modified_by,
+                    modified_at
+            "#,
+        )
+        .bind(extension.assignment_id)
+        .bind(extension.student_id)
+        .bind(extension.due_at)
+        .bind(extension.modified_by)
+        .fetch_one(&self.pool)
+        .await?;
+        Ok(row)
+    }
+
+    async fn delete_student_extension(
+        &self,
+        assignment_id: Uuid,
+        student_id: Uuid,
+    ) -> Result<bool, Error> {
+        let result = sqlx::query(
+            r#"
+                DELETE FROM assignment_student_extensions
+                WHERE assignment_id = $1 AND student_id = $2
+            "#,
+        )
+        .bind(assignment_id)
+        .bind(student_id)
+        .execute(&self.pool)
+        .await?;
+        Ok(result.rows_affected() > 0)
+    }
+
     async fn add_attachment(
         &self,
         assignment_id: Uuid,
@@ -216,7 +380,7 @@ impl AssignmentRepositoryTrait for AssignmentRepository {
                 INSERT INTO assignment_attachments (assignment_id, file_id, created_by)
                 VALUES ($1, $2, $3)
                 ON CONFLICT (assignment_id, file_id) DO NOTHING
-                "#,
+            "#,
         )
         .bind(assignment_id)
         .bind(file_id)
@@ -224,14 +388,12 @@ impl AssignmentRepositoryTrait for AssignmentRepository {
         .execute(&self.pool)
         .await?;
 
-        // Best-effort enqueue for asynchronous grading workers.
-        // This allows older environments (without the new migration) to continue working.
         let enqueue_result = sqlx::query(
             r#"
                 INSERT INTO grading_jobs (assignment_id, file_id, submitted_by, status)
                 VALUES ($1, $2, $3, 'queued')
                 ON CONFLICT (assignment_id, file_id) DO NOTHING
-                "#,
+            "#,
         )
         .bind(assignment_id)
         .bind(file_id)
@@ -256,7 +418,7 @@ impl AssignmentRepositoryTrait for AssignmentRepository {
             r#"
                 DELETE FROM assignment_attachments
                 WHERE assignment_id = $1 AND file_id = $2
-                "#,
+            "#,
         )
         .bind(assignment_id)
         .bind(file_id)
@@ -275,19 +437,19 @@ impl AssignmentRepositoryTrait for AssignmentRepository {
                     id, class_id, title, description, due_at, deadline_type, points, created_by, modified_by
                 )
                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
-                "#,
+            "#,
         )
-            .bind(id)
-            .bind(assignment.class_id)
-            .bind(assignment.title.clone())
-            .bind(assignment.description.clone())
-            .bind(assignment.due_at)
-            .bind(assignment.deadline_type)
-            .bind(assignment.points)
-            .bind(assignment.modified_by)
-            .bind(assignment.modified_by)
-            .execute(&mut *tx)
-            .await?;
+        .bind(id)
+        .bind(assignment.class_id)
+        .bind(assignment.title.clone())
+        .bind(assignment.description.clone())
+        .bind(assignment.due_at)
+        .bind(assignment.deadline_type)
+        .bind(assignment.points)
+        .bind(assignment.modified_by)
+        .bind(assignment.modified_by)
+        .execute(&mut *tx)
+        .await?;
 
         tx.commit().await?;
         Ok(id)

--- a/apps/libgrader/src/domains/assignments/infra/impl_service.rs
+++ b/apps/libgrader/src/domains/assignments/infra/impl_service.rs
@@ -7,7 +7,8 @@ use crate::domains::assignments::domain::{
     service::AssignmentServiceTrait,
 };
 use crate::domains::assignments::dto::assignment_dto::{
-    AssignmentDto, AssignmentWithAttachmentCountDto, CreateAssignmentDto, UpdateAssignmentDto,
+    AssignmentDto, AssignmentWithAttachmentCountDto, CreateAssignmentDto,
+    StudentAssignmentExtensionDto, UpdateAssignmentDto, UpsertStudentAssignmentExtensionDto,
 };
 use async_trait::async_trait;
 use sqlx::PgPool;
@@ -66,6 +67,24 @@ where
         }
     }
 
+    async fn list_by_class_for_student(
+        &self,
+        class_id: Uuid,
+        student_id: Uuid,
+    ) -> Result<Vec<AssignmentDto>, AppError> {
+        match self
+            .repository
+            .find_by_class_id_for_student(class_id, student_id)
+            .await
+        {
+            Ok(assignments) => Ok(assignments.into_iter().map(Into::into).collect()),
+            Err(err) => {
+                tracing::error!("Error fetching assignments by class for student: {err}");
+                Err(AppError::DatabaseError(err))
+            }
+        }
+    }
+
     async fn list_by_class_with_attachment_count(
         &self,
         class_id: Uuid,
@@ -114,6 +133,48 @@ where
             })
     }
 
+    async fn list_student_extensions(
+        &self,
+        assignment_id: Uuid,
+    ) -> Result<Vec<StudentAssignmentExtensionDto>, AppError> {
+        self.repository
+            .list_student_extensions(assignment_id)
+            .await
+            .map(|rows| rows.into_iter().map(Into::into).collect())
+            .map_err(|err| {
+                tracing::error!("Error fetching student assignment extensions: {err}");
+                AppError::DatabaseError(err)
+            })
+    }
+
+    async fn upsert_student_extension(
+        &self,
+        extension: UpsertStudentAssignmentExtensionDto,
+    ) -> Result<StudentAssignmentExtensionDto, AppError> {
+        self.repository
+            .upsert_student_extension(extension)
+            .await
+            .map(Into::into)
+            .map_err(|err| {
+                tracing::error!("Error saving student assignment extension: {err}");
+                AppError::DatabaseError(err)
+            })
+    }
+
+    async fn delete_student_extension(
+        &self,
+        assignment_id: Uuid,
+        student_id: Uuid,
+    ) -> Result<bool, AppError> {
+        self.repository
+            .delete_student_extension(assignment_id, student_id)
+            .await
+            .map_err(|err| {
+                tracing::error!("Error deleting student assignment extension: {err}");
+                AppError::DatabaseError(err)
+            })
+    }
+
     async fn attach_file(
         &self,
         assignment_id: Uuid,
@@ -145,6 +206,21 @@ where
             Ok(None) => Err(AppError::NotFound("Assignment not found".into())),
             Err(err) => {
                 tracing::error!("Error retrieving assignment: {err}");
+                Err(AppError::DatabaseError(err))
+            }
+        }
+    }
+
+    async fn find_by_id_for_student(
+        &self,
+        id: Uuid,
+        student_id: Uuid,
+    ) -> Result<Option<AssignmentDto>, AppError> {
+        match self.repository.find_by_id_for_student(id, student_id).await {
+            Ok(Some(assignment)) => Ok(Some(AssignmentDto::from(assignment))),
+            Ok(None) => Err(AppError::NotFound("Assignment not found".into())),
+            Err(err) => {
+                tracing::error!("Error retrieving assignment for student: {err}");
                 Err(AppError::DatabaseError(err))
             }
         }

--- a/apps/web/migrations/20260317193000_create_assignment_student_extensions.sql
+++ b/apps/web/migrations/20260317193000_create_assignment_student_extensions.sql
@@ -1,0 +1,38 @@
+CREATE TABLE assignment_student_extensions
+(
+    assignment_id uuid        NOT NULL,
+    student_id    uuid        NOT NULL,
+    due_at        TIMESTAMPTZ NOT NULL,
+    created_by    uuid,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    modified_by   uuid,
+    modified_at   TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    PRIMARY KEY (assignment_id, student_id),
+
+    FOREIGN KEY (assignment_id)
+        REFERENCES assignments (id)
+        ON UPDATE CASCADE
+        ON DELETE CASCADE,
+
+    FOREIGN KEY (student_id)
+        REFERENCES users (id)
+        ON UPDATE CASCADE
+        ON DELETE CASCADE,
+
+    FOREIGN KEY (created_by)
+        REFERENCES users (id)
+        ON UPDATE CASCADE
+        ON DELETE SET NULL,
+
+    FOREIGN KEY (modified_by)
+        REFERENCES users (id)
+        ON UPDATE CASCADE
+        ON DELETE SET NULL
+);
+
+CREATE INDEX idx_assignment_student_extensions_assignment_id
+    ON assignment_student_extensions (assignment_id);
+
+CREATE INDEX idx_assignment_student_extensions_student_id
+    ON assignment_student_extensions (student_id);

--- a/apps/web/src/web/instructors.rs
+++ b/apps/web/src/web/instructors.rs
@@ -15,7 +15,9 @@ use uuid::Uuid;
 use crate::common::error::AppError;
 use crate::common::jwt::Claims;
 use crate::common::multipart_helper::parse_multipart_to_maps;
-use crate::domains::assignments::dto::assignment_dto::UpdateAssignmentDto;
+use crate::domains::assignments::dto::assignment_dto::{
+    UpdateAssignmentDto, UpsertStudentAssignmentExtensionDto,
+};
 use crate::domains::assignments::{AssignmentDeadlineType, AssignmentServiceTrait};
 use crate::domains::class_memberships::{
     ClassMembershipRole, ClassMembershipServiceTrait,
@@ -53,6 +55,31 @@ where
     }
 }
 
+#[derive(Clone)]
+pub struct InstructorAssignmentEditDeps {
+    assignment_service: Arc<dyn AssignmentServiceTrait>,
+    class_service: Arc<dyn ClassServiceTrait>,
+    class_membership_service: Arc<dyn ClassMembershipServiceTrait>,
+    user_service: Arc<dyn UserServiceTrait>,
+}
+
+impl<S> FromRef<S> for InstructorAssignmentEditDeps
+where
+    Arc<dyn AssignmentServiceTrait>: FromRef<S>,
+    Arc<dyn ClassServiceTrait>: FromRef<S>,
+    Arc<dyn ClassMembershipServiceTrait>: FromRef<S>,
+    Arc<dyn UserServiceTrait>: FromRef<S>,
+{
+    fn from_ref(input: &S) -> Self {
+        Self {
+            assignment_service: Arc::<dyn AssignmentServiceTrait>::from_ref(input),
+            class_service: Arc::<dyn ClassServiceTrait>::from_ref(input),
+            class_membership_service: Arc::<dyn ClassMembershipServiceTrait>::from_ref(input),
+            user_service: Arc::<dyn UserServiceTrait>::from_ref(input),
+        }
+    }
+}
+
 #[derive(Debug, serde::Serialize)]
 struct InstructorStudentSubmissionRow {
     file_id: Uuid,
@@ -65,12 +92,60 @@ struct InstructorStudentSubmissionRow {
     grading_completed_at: Option<DateTime<Utc>>,
 }
 
+#[derive(Clone, Debug, serde::Serialize)]
+struct InstructorStudentExtensionRow {
+    user_id: Uuid,
+    username: String,
+    email: Option<String>,
+    extension_due_at: Option<DateTime<Utc>>,
+    effective_due_at: Option<DateTime<Utc>>,
+}
+
 fn parse_deadline_type(value: &str) -> Result<AssignmentDeadlineType, AppError> {
     match value {
         "hard_cutoff" => Ok(AssignmentDeadlineType::HardCutoff),
         "soft_deadline" => Ok(AssignmentDeadlineType::SoftDeadline),
         _ => Err(AppError::ValidationError("Invalid deadline type".into())),
     }
+}
+
+async fn build_assignment_extension_rows(
+    assignment_service: &Arc<dyn AssignmentServiceTrait>,
+    class_membership_service: &Arc<dyn ClassMembershipServiceTrait>,
+    user_service: &Arc<dyn UserServiceTrait>,
+    class_id: Uuid,
+    assignment_id: Uuid,
+    default_due_at: Option<DateTime<Utc>>,
+) -> Result<Vec<InstructorStudentExtensionRow>, AppError> {
+    let memberships = class_membership_service.list_by_class_id(class_id).await?;
+    let users = user_service.get_users().await?;
+    let user_by_id: HashMap<Uuid, _> = users.iter().map(|user| (user.id, user)).collect();
+    let extensions = assignment_service
+        .list_student_extensions(assignment_id)
+        .await?;
+    let extension_by_student = extensions
+        .into_iter()
+        .map(|extension| (extension.student_id, extension))
+        .collect::<HashMap<_, _>>();
+
+    Ok(memberships
+        .iter()
+        .filter(|membership| matches!(membership.role, ClassMembershipRole::Student))
+        .filter_map(|membership| {
+            user_by_id.get(&membership.user_id).map(|user| {
+                let extension_due_at = extension_by_student
+                    .get(&membership.user_id)
+                    .map(|extension| extension.due_at);
+                InstructorStudentExtensionRow {
+                    user_id: user.id,
+                    username: user.username.clone(),
+                    email: user.email.clone(),
+                    extension_due_at,
+                    effective_due_at: extension_due_at.or(default_due_at),
+                }
+            })
+        })
+        .collect())
 }
 
 pub async fn instructors_page(
@@ -546,22 +621,15 @@ pub async fn edit_assignment_page(
         return Err(AppError::Forbidden);
     }
 
-    let memberships = class_membership_service.list_by_class_id(class.id).await?;
-    let users = user_service.get_users().await?;
-    let user_by_id: HashMap<Uuid, _> = users.iter().map(|user| (user.id, user)).collect();
-    let roster_members = memberships
-        .iter()
-        .filter(|membership| matches!(membership.role, ClassMembershipRole::Student))
-        .filter_map(|membership| {
-            user_by_id.get(&membership.user_id).map(|user| {
-                context! {
-                    user_id => user.id,
-                    username => user.username.clone(),
-                    email => user.email.clone(),
-                }
-            })
-        })
-        .collect::<Vec<_>>();
+    let roster_members = build_assignment_extension_rows(
+        &assignment_service,
+        &class_membership_service,
+        &user_service,
+        class.id,
+        assignment_id,
+        assignment.due_at,
+    )
+    .await?;
 
     let authenticity_token = token
         .authenticity_token()
@@ -584,6 +652,7 @@ pub async fn edit_assignment_page(
             due_at_value => assignment.due_at,
             deadline_type_value => assignment.deadline_type,
             points_value => assignment.points,
+            default_due_at => assignment.due_at,
             authenticity_token => authenticity_token,
         },
     )?;
@@ -603,7 +672,7 @@ pub async fn instructor_student_submission_history_page(
     }
 
     let assignment = assignment_service
-        .find_by_id(assignment_id)
+        .find_by_id_for_student(assignment_id, student_id)
         .await?
         .ok_or_else(|| AppError::NotFound("Assignment not found".into()))?;
 
@@ -657,6 +726,9 @@ pub async fn instructor_student_submission_history_page(
             assignment => assignment,
             student => student,
             submissions => submissions,
+            default_due_at => assignment.due_at,
+            effective_due_at => assignment.effective_due_at.or(assignment.due_at),
+            extension_due_at => assignment.extension_due_at,
         },
     )?;
     Ok(Html(html))
@@ -664,8 +736,7 @@ pub async fn instructor_student_submission_history_page(
 
 pub async fn edit_assignment_submit(
     Path(assignment_id): Path<Uuid>,
-    State(assignment_service): State<Arc<dyn AssignmentServiceTrait>>,
-    State(class_service): State<Arc<dyn ClassServiceTrait>>,
+    State(deps): State<InstructorAssignmentEditDeps>,
     Extension(claims): Extension<Claims>,
     token: CsrfToken,
     Form(form): Form<EditAssignmentForm>,
@@ -678,12 +749,14 @@ pub async fn edit_assignment_submit(
         return Err(AppError::Forbidden);
     }
 
-    let assignment = assignment_service
+    let assignment = deps
+        .assignment_service
         .find_by_id(assignment_id)
         .await?
         .ok_or_else(|| AppError::NotFound("Assignment not found".into()))?;
 
-    let existing = class_service
+    let existing = deps
+        .class_service
         .find_by_id(assignment.class_id)
         .await?
         .ok_or_else(|| AppError::NotFound("Class not found".into()))?;
@@ -692,7 +765,19 @@ pub async fn edit_assignment_submit(
         return Err(AppError::Forbidden);
     }
 
-    let attachments = assignment_service.list_attachments(assignment_id).await?;
+    let attachments = deps
+        .assignment_service
+        .list_attachments(assignment_id)
+        .await?;
+    let roster_members = build_assignment_extension_rows(
+        &deps.assignment_service,
+        &deps.class_membership_service,
+        &deps.user_service,
+        existing.id,
+        assignment_id,
+        assignment.due_at,
+    )
+    .await?;
 
     let title = form.title.trim().to_string();
     let description_value = form.description.as_deref().unwrap_or("").trim().to_string();
@@ -717,6 +802,8 @@ pub async fn edit_assignment_submit(
                 due_at_value => due_at_value,
                 deadline_type_value => deadline_type_value,
                 points_value => points,
+                default_due_at => assignment.due_at,
+                roster_members => roster_members.clone(),
                 authenticity_token => token.authenticity_token().unwrap_or_default(),
             },
         )?;
@@ -750,7 +837,7 @@ pub async fn edit_assignment_submit(
         modified_by: claims.sub,
     };
 
-    match assignment_service.update(payload).await {
+    match deps.assignment_service.update(payload).await {
         Ok(updated) => Ok((
             StatusCode::SEE_OTHER,
             Redirect::to(&format!("/ui/instructors/classes/{}", updated.class_id)),
@@ -773,6 +860,8 @@ pub async fn edit_assignment_submit(
                     deadline_type_value => deadline_type_value,
                     description_value => description_value,
                     points_value => points,
+                    default_due_at => assignment.due_at,
+                    roster_members => roster_members,
                     authenticity_token => token.authenticity_token().unwrap_or_default(),
                 },
             )?;
@@ -781,6 +870,112 @@ pub async fn edit_assignment_submit(
             Ok(response)
         }
     }
+}
+
+pub async fn upsert_student_assignment_extension(
+    Path((assignment_id, student_id)): Path<(Uuid, Uuid)>,
+    State(assignment_service): State<Arc<dyn AssignmentServiceTrait>>,
+    State(class_service): State<Arc<dyn ClassServiceTrait>>,
+    State(class_membership_service): State<Arc<dyn ClassMembershipServiceTrait>>,
+    Extension(claims): Extension<Claims>,
+    token: CsrfToken,
+    Form(form): Form<StudentAssignmentExtensionForm>,
+) -> Result<Response, AppError> {
+    if !matches!(claims.user_role, UserRole::Instructor | UserRole::Admin) {
+        return Err(AppError::Forbidden);
+    }
+
+    if token.verify(&form.authenticity_token).is_err() {
+        return Err(AppError::Forbidden);
+    }
+
+    let assignment = assignment_service
+        .find_by_id(assignment_id)
+        .await?
+        .ok_or_else(|| AppError::NotFound("Assignment not found".into()))?;
+
+    let class = class_service
+        .find_by_id(assignment.class_id)
+        .await?
+        .ok_or_else(|| AppError::NotFound("Class not found".into()))?;
+
+    if !matches!(claims.user_role, UserRole::Admin) && class.owner_id != Some(claims.sub) {
+        return Err(AppError::Forbidden);
+    }
+
+    let is_enrolled = class_membership_service
+        .list_by_class_id(class.id)
+        .await?
+        .iter()
+        .any(|membership| {
+            membership.user_id == student_id
+                && matches!(membership.role, ClassMembershipRole::Student)
+        });
+    if !is_enrolled {
+        return Err(AppError::NotFound(
+            "Student is not enrolled in this class".into(),
+        ));
+    }
+
+    let due_at_value = form.due_at.trim();
+    let due_at = NaiveDateTime::parse_from_str(due_at_value, "%Y-%m-%dT%H:%M")
+        .map_err(|_| AppError::ValidationError("Invalid extension due date format".into()))?;
+
+    assignment_service
+        .upsert_student_extension(UpsertStudentAssignmentExtensionDto {
+            assignment_id,
+            student_id,
+            due_at: DateTime::<Utc>::from_naive_utc_and_offset(due_at, Utc),
+            modified_by: claims.sub,
+        })
+        .await?;
+
+    Ok((
+        StatusCode::SEE_OTHER,
+        Redirect::to(&format!("/ui/instructors/assignments/{assignment_id}/edit")),
+    )
+        .into_response())
+}
+
+pub async fn delete_student_assignment_extension(
+    Path((assignment_id, student_id)): Path<(Uuid, Uuid)>,
+    State(assignment_service): State<Arc<dyn AssignmentServiceTrait>>,
+    State(class_service): State<Arc<dyn ClassServiceTrait>>,
+    Extension(claims): Extension<Claims>,
+    token: CsrfToken,
+    Form(form): Form<DeleteStudentAssignmentExtensionForm>,
+) -> Result<Response, AppError> {
+    if !matches!(claims.user_role, UserRole::Instructor | UserRole::Admin) {
+        return Err(AppError::Forbidden);
+    }
+
+    if token.verify(&form.authenticity_token).is_err() {
+        return Err(AppError::Forbidden);
+    }
+
+    let assignment = assignment_service
+        .find_by_id(assignment_id)
+        .await?
+        .ok_or_else(|| AppError::NotFound("Assignment not found".into()))?;
+
+    let class = class_service
+        .find_by_id(assignment.class_id)
+        .await?
+        .ok_or_else(|| AppError::NotFound("Class not found".into()))?;
+
+    if !matches!(claims.user_role, UserRole::Admin) && class.owner_id != Some(claims.sub) {
+        return Err(AppError::Forbidden);
+    }
+
+    assignment_service
+        .delete_student_extension(assignment_id, student_id)
+        .await?;
+
+    Ok((
+        StatusCode::SEE_OTHER,
+        Redirect::to(&format!("/ui/instructors/assignments/{assignment_id}/edit")),
+    )
+        .into_response())
 }
 
 pub async fn upload_assignment_attachments(
@@ -891,4 +1086,15 @@ pub struct EditAssignmentForm {
     deadline_type: String,
     authenticity_token: String,
     points: i16,
+}
+
+#[derive(serde::Deserialize)]
+pub struct StudentAssignmentExtensionForm {
+    due_at: String,
+    authenticity_token: String,
+}
+
+#[derive(serde::Deserialize)]
+pub struct DeleteStudentAssignmentExtensionForm {
+    authenticity_token: String,
 }

--- a/apps/web/src/web/routes.rs
+++ b/apps/web/src/web/routes.rs
@@ -22,10 +22,11 @@ use super::{
     },
     htmx::assignments::assignments_table_fragment,
     instructors::{
-        add_student_to_roster, create_class_page, create_class_submit, edit_assignment_page,
-        edit_assignment_submit, edit_class_page, edit_class_submit, instructor_class_detail_page,
+        add_student_to_roster, create_class_page, create_class_submit,
+        delete_student_assignment_extension, edit_assignment_page, edit_assignment_submit,
+        edit_class_page, edit_class_submit, instructor_class_detail_page,
         instructor_student_submission_history_page, instructors_page, remove_student_from_roster,
-        upload_assignment_attachments,
+        upload_assignment_attachments, upsert_student_assignment_extension,
     },
     students::{
         student_assignment_detail_page, students_assignments_page, students_classes_page,
@@ -93,6 +94,14 @@ where
         .route(
             "/ui/instructors/assignments/{id}/attachments",
             post(upload_assignment_attachments),
+        )
+        .route(
+            "/ui/instructors/assignments/{assignment_id}/students/{student_id}/extension",
+            post(upsert_student_assignment_extension),
+        )
+        .route(
+            "/ui/instructors/assignments/{assignment_id}/students/{student_id}/extension/delete",
+            post(delete_student_assignment_extension),
         )
         .route(
             "/ui/instructors/assignments/{assignment_id}/students/{student_id}/submissions",

--- a/apps/web/src/web/students.rs
+++ b/apps/web/src/web/students.rs
@@ -87,6 +87,8 @@ struct StudentAssignmentRow {
     title: String,
     description: Option<String>,
     due_at: Option<chrono::DateTime<chrono::Utc>>,
+    extension_due_at: Option<chrono::DateTime<chrono::Utc>>,
+    effective_due_at: Option<chrono::DateTime<chrono::Utc>>,
     deadline_type: AssignmentDeadlineType,
     points: Option<i16>,
 }
@@ -111,7 +113,9 @@ pub async fn students_assignments_page(
             None => continue,
         };
 
-        let assignments = assignment_service.list_by_class(class.id).await?;
+        let assignments = assignment_service
+            .list_by_class_for_student(class.id, claims.sub)
+            .await?;
         for assignment in assignments {
             rows.push(StudentAssignmentRow {
                 id: assignment.id,
@@ -119,6 +123,8 @@ pub async fn students_assignments_page(
                 title: assignment.title,
                 description: assignment.description,
                 due_at: assignment.due_at,
+                extension_due_at: assignment.extension_due_at,
+                effective_due_at: assignment.effective_due_at,
                 deadline_type: assignment.deadline_type,
                 points: assignment.points,
             });
@@ -172,7 +178,7 @@ async fn get_student_assignment_context(
     AppError,
 > {
     let assignment = assignment_service
-        .find_by_id(assignment_id)
+        .find_by_id_for_student(assignment_id, claims.sub)
         .await?
         .ok_or_else(|| AppError::NotFound("Assignment not found".into()))?;
 
@@ -188,6 +194,7 @@ async fn get_student_assignment_context(
         return Err(AppError::Forbidden);
     }
 
+    let effective_due_at = assignment.effective_due_at.or(assignment.due_at);
     let submission_files = assignment_service
         .list_attachments(assignment_id)
         .await?
@@ -202,9 +209,7 @@ async fn get_student_assignment_context(
             is_late: matches!(
                 assignment.deadline_type,
                 AssignmentDeadlineType::SoftDeadline
-            ) && assignment
-                .due_at
-                .is_some_and(|due_at| a.created_at > due_at),
+            ) && effective_due_at.is_some_and(|due_at| a.created_at > due_at),
         })
         .collect::<Vec<_>>();
 
@@ -313,8 +318,9 @@ pub async fn submit_student_assignment(
         return Ok((StatusCode::BAD_REQUEST, token, Html(html)).into_response());
     }
 
+    let effective_due_at = assignment.effective_due_at.or(assignment.due_at);
     if matches!(assignment.deadline_type, AssignmentDeadlineType::HardCutoff)
-        && assignment.due_at.is_some_and(|due_at| Utc::now() > due_at)
+        && effective_due_at.is_some_and(|due_at| Utc::now() > due_at)
     {
         let html = render_template(
             "assignments/student_detail.html",

--- a/apps/web/templates/assignments/create_assignment.html
+++ b/apps/web/templates/assignments/create_assignment.html
@@ -84,8 +84,8 @@
     {% if assignment and roster_members and roster_members|length > 0 %}
     <section class="mt-6 rounded-xl border border-slate-200 bg-slate-50 p-5 shadow-sm">
         <header class="mb-3 space-y-1">
-            <h2 class="text-xl font-semibold">Student Submission History</h2>
-            <p class="text-sm text-slate-600">Open a student-specific history view for this assignment.</p>
+            <h2 class="text-xl font-semibold">Student Extensions</h2>
+            <p class="text-sm text-slate-600">Override the assignment due date for individual students without changing the class default.</p>
         </header>
         <div class="table-frame rounded-lg border border-slate-200 bg-white">
             <table class="min-w-full divide-y divide-slate-200 text-sm">
@@ -93,6 +93,8 @@
                 <tr>
                     <th class="px-4 py-2 text-left font-medium text-slate-600">Student</th>
                     <th class="px-4 py-2 text-left font-medium text-slate-600">Email</th>
+                    <th class="px-4 py-2 text-left font-medium text-slate-600">Effective Due</th>
+                    <th class="px-4 py-2 text-left font-medium text-slate-600">Student Extension</th>
                     <th class="px-4 py-2 text-right font-medium text-slate-600">Actions</th>
                 </tr>
                 </thead>
@@ -101,7 +103,39 @@
                 <tr>
                     <td class="px-4 py-2 font-medium text-slate-900">{{ member.username }}</td>
                     <td class="px-4 py-2 text-slate-700">{{ member.email or "-" }}</td>
+                    <td class="px-4 py-2 text-slate-700">
+                        {% if member.effective_due_at %}
+                        {{ member.effective_due_at|format_datetime_display }}
+                        {% else %}
+                        -
+                        {% endif %}
+                    </td>
+                    <td class="px-4 py-2 text-slate-700">
+                        <form method="post"
+                              action="/ui/instructors/assignments/{{ assignment.id }}/students/{{ member.user_id }}/extension"
+                              class="flex flex-wrap items-end gap-2">
+                            <input type="hidden" name="authenticity_token" value="{{ authenticity_token|safe }}"/>
+                            <input type="datetime-local"
+                                   name="due_at"
+                                   value="{% if member.extension_due_at %}{{ member.extension_due_at|format_datetime_local }}{% endif %}"
+                                   class="auth-input min-w-56"/>
+                            <button type="submit" class="rounded-md border border-slate-300 px-3 py-2 text-xs font-medium hover:bg-slate-100">
+                                Save Extension
+                            </button>
+                        </form>
+                    </td>
                     <td class="px-4 py-2 text-right">
+                        {% if member.extension_due_at %}
+                        <form method="post"
+                              action="/ui/instructors/assignments/{{ assignment.id }}/students/{{ member.user_id }}/extension/delete"
+                              class="inline">
+                            <input type="hidden" name="authenticity_token" value="{{ authenticity_token|safe }}"/>
+                            <button type="submit"
+                                    class="rounded-md border border-rose-300 px-3 py-1 text-xs font-medium text-rose-700 hover:bg-rose-50">
+                                Remove Extension
+                            </button>
+                        </form>
+                        {% endif %}
                         <a class="rounded-md border border-slate-300 px-3 py-1 text-xs font-medium hover:bg-slate-100"
                            href="/ui/instructors/assignments/{{ assignment.id }}/students/{{ member.user_id }}/submissions">
                             View History

--- a/apps/web/templates/assignments/instructor_submission_history.html
+++ b/apps/web/templates/assignments/instructor_submission_history.html
@@ -15,6 +15,39 @@
 </header>
 
 <section class="rounded-xl border border-slate-200 bg-white p-5 shadow-sm space-y-3">
+    <div class="grid gap-3 md:grid-cols-3">
+        <div>
+            <dt class="text-xs uppercase tracking-wide text-slate-500">Default Due</dt>
+            <dd class="text-slate-800">
+                {% if default_due_at %}
+                {{ default_due_at|format_datetime_display }}
+                {% else %}
+                -
+                {% endif %}
+            </dd>
+        </div>
+        <div>
+            <dt class="text-xs uppercase tracking-wide text-slate-500">Extension</dt>
+            <dd class="text-slate-800">
+                {% if extension_due_at %}
+                {{ extension_due_at|format_datetime_display }}
+                {% else %}
+                -
+                {% endif %}
+            </dd>
+        </div>
+        <div>
+            <dt class="text-xs uppercase tracking-wide text-slate-500">Effective Due</dt>
+            <dd class="text-slate-800">
+                {% if effective_due_at %}
+                {{ effective_due_at|format_datetime_display }}
+                {% else %}
+                -
+                {% endif %}
+            </dd>
+        </div>
+    </div>
+
     <div class="flex items-center justify-between gap-3">
         <h2 class="text-xl font-semibold">Attempts</h2>
         <span class="text-sm text-slate-500">{{ submissions|length }} total</span>

--- a/apps/web/templates/assignments/student_detail.html
+++ b/apps/web/templates/assignments/student_detail.html
@@ -39,9 +39,17 @@
         <div>
             <dt class="text-xs uppercase tracking-wide text-slate-500">Due Date</dt>
             <dd class="text-slate-800">
-                {% if assignment.due_at %}
-                {{ assignment.due_at|format_datetime_display }}
+                {% if assignment.effective_due_at or assignment.due_at %}
+                {{ (assignment.effective_due_at or assignment.due_at)|format_datetime_display }}
                 <div class="text-xs text-slate-500 mt-1">{{ assignment.deadline_type|format_deadline_type }}</div>
+                {% if assignment.extension_due_at %}
+                <div class="text-xs text-emerald-700 mt-1">
+                    Extension applied
+                    {% if assignment.due_at %}
+                    · default {{ assignment.due_at|format_datetime_display }}
+                    {% endif %}
+                </div>
+                {% endif %}
                 {% else %}
                 -
                 {% endif %}

--- a/apps/web/templates/assignments/student_index.html
+++ b/apps/web/templates/assignments/student_index.html
@@ -35,9 +35,17 @@
                 <td class="px-4 py-2 text-slate-700">{{ assignment.title }}</td>
                 <td class="px-4 py-2 text-slate-700">{{ assignment.description or "-" }}</td>
                 <td class="px-4 py-2 text-slate-700">
-                    {% if assignment.due_at %}
-                    {{ assignment.due_at|format_datetime_display }}
+                    {% if assignment.effective_due_at or assignment.due_at %}
+                    {{ (assignment.effective_due_at or assignment.due_at)|format_datetime_display }}
                     <div class="text-xs text-slate-500 mt-1">{{ assignment.deadline_type|format_deadline_type }}</div>
+                    {% if assignment.extension_due_at %}
+                    <div class="text-xs text-emerald-700 mt-1">
+                        Extension applied
+                        {% if assignment.due_at %}
+                        · default {{ assignment.due_at|format_datetime_display }}
+                        {% endif %}
+                    </div>
+                    {% endif %}
                     {% else %}
                     -
                     {% endif %}

--- a/apps/web/tests/domains/assignments/test_assignment_routes.rs
+++ b/apps/web/tests/domains/assignments/test_assignment_routes.rs
@@ -9,7 +9,8 @@ use grade_o_matic_web::common::dto::RestApiResponse;
 use grade_o_matic_web::common::error::AppError;
 use grade_o_matic_web::common::jwt::Claims;
 use grade_o_matic_web::domains::assignments::dto::assignment_dto::{
-    AssignmentDto, AssignmentWithAttachmentCountDto, CreateAssignmentDto, UpdateAssignmentDto,
+    AssignmentDto, AssignmentWithAttachmentCountDto, CreateAssignmentDto,
+    StudentAssignmentExtensionDto, UpdateAssignmentDto, UpsertStudentAssignmentExtensionDto,
 };
 use grade_o_matic_web::domains::assignments::{
     AssignmentAttachment, AssignmentDeadlineType, AssignmentServiceTrait,
@@ -49,6 +50,8 @@ impl FakeAssignmentService {
             title: "Seed Assignment".to_string(),
             description: Some("This is a seed assignment for testing purposes.".to_string()),
             due_at: Some(Utc::now()),
+            extension_due_at: None,
+            effective_due_at: Some(Utc::now()),
             deadline_type: AssignmentDeadlineType::SoftDeadline,
             points: Some(100),
         };
@@ -81,6 +84,14 @@ impl AssignmentServiceTrait for FakeAssignmentService {
         Ok(store.assignments.values().cloned().collect())
     }
 
+    async fn list_by_class_for_student(
+        &self,
+        _class_id: Uuid,
+        _student_id: Uuid,
+    ) -> Result<Vec<AssignmentDto>, AppError> {
+        self.list_by_class(_class_id).await
+    }
+
     async fn list_by_class_with_attachment_count(
         &self,
         _class_id: Uuid,
@@ -96,6 +107,8 @@ impl AssignmentServiceTrait for FakeAssignmentService {
                 title: assignment.title,
                 description: assignment.description,
                 due_at: assignment.due_at,
+                extension_due_at: assignment.extension_due_at,
+                effective_due_at: assignment.effective_due_at,
                 deadline_type: assignment.deadline_type,
                 points: assignment.points,
                 attachment_count: 0,
@@ -116,6 +129,28 @@ impl AssignmentServiceTrait for FakeAssignmentService {
         _student_id: Uuid,
     ) -> Result<Vec<StudentAssignmentSubmission>, AppError> {
         Ok(vec![])
+    }
+
+    async fn list_student_extensions(
+        &self,
+        _assignment_id: Uuid,
+    ) -> Result<Vec<StudentAssignmentExtensionDto>, AppError> {
+        Ok(vec![])
+    }
+
+    async fn upsert_student_extension(
+        &self,
+        _extension: UpsertStudentAssignmentExtensionDto,
+    ) -> Result<StudentAssignmentExtensionDto, AppError> {
+        Err(AppError::InternalError)
+    }
+
+    async fn delete_student_extension(
+        &self,
+        _assignment_id: Uuid,
+        _student_id: Uuid,
+    ) -> Result<bool, AppError> {
+        Ok(true)
     }
 
     async fn attach_file(
@@ -139,6 +174,14 @@ impl AssignmentServiceTrait for FakeAssignmentService {
         }
     }
 
+    async fn find_by_id_for_student(
+        &self,
+        id: Uuid,
+        _student_id: Uuid,
+    ) -> Result<Option<AssignmentDto>, AppError> {
+        self.find_by_id(id).await
+    }
+
     async fn create(&self, assignment: CreateAssignmentDto) -> Result<AssignmentDto, AppError> {
         let id = Uuid::new_v4();
 
@@ -148,6 +191,8 @@ impl AssignmentServiceTrait for FakeAssignmentService {
             title: assignment.title,
             description: assignment.description,
             due_at: assignment.due_at,
+            extension_due_at: None,
+            effective_due_at: assignment.due_at,
             deadline_type: assignment.deadline_type,
             points: None,
         };

--- a/apps/web/tests/domains/assignments/test_assignments_service.rs
+++ b/apps/web/tests/domains/assignments/test_assignments_service.rs
@@ -7,8 +7,10 @@ use grade_o_matic_web::{
     domains::assignments::{
         Assignment, AssignmentAttachment, AssignmentDeadlineType, AssignmentRepositoryTrait,
         AssignmentService, AssignmentServiceTrait, AssignmentWithAttachmentCount,
-        StudentAssignmentSubmission, create_assignment_service,
-        dto::assignment_dto::{CreateAssignmentDto, UpdateAssignmentDto},
+        StudentAssignmentExtension, StudentAssignmentSubmission, create_assignment_service,
+        dto::assignment_dto::{
+            CreateAssignmentDto, UpdateAssignmentDto, UpsertStudentAssignmentExtensionDto,
+        },
     },
 };
 use sqlx::{Error, PgPool};
@@ -21,10 +23,12 @@ struct FakeAssignmentRepository {
     fail_find_all: bool,
     fail_find_by_class_id: bool,
     fail_find_by_class_id_with_count: bool,
+    student_extensions: Mutex<HashMap<(Uuid, Uuid), StudentAssignmentExtension>>,
     list_attachments_result: Vec<AssignmentAttachment>,
     list_student_submission_history_result: Vec<StudentAssignmentSubmission>,
     fail_list_attachments: bool,
     fail_list_student_submission_history: bool,
+    fail_student_extension_ops: bool,
     fail_add_attachment: bool,
     fail_remove_attachment: bool,
     remove_attachment_result: bool,
@@ -65,6 +69,22 @@ impl AssignmentRepositoryTrait for FakeAssignmentRepository {
             .collect())
     }
 
+    async fn find_by_class_id_for_student(
+        &self,
+        class_id: Uuid,
+        student_id: Uuid,
+    ) -> Result<Vec<Assignment>, sqlx::Error> {
+        let mut assignments = self.find_by_class_id(class_id).await?;
+        let extensions = self.student_extensions.lock().await;
+        for assignment in &mut assignments {
+            if let Some(extension) = extensions.get(&(assignment.id, student_id)) {
+                assignment.extension_due_at = Some(extension.due_at);
+                assignment.effective_due_at = Some(extension.due_at);
+            }
+        }
+        Ok(assignments)
+    }
+
     async fn find_by_class_id_with_attachment_count(
         &self,
         class_id: Uuid,
@@ -83,6 +103,8 @@ impl AssignmentRepositoryTrait for FakeAssignmentRepository {
                 title: assignment.title,
                 description: assignment.description,
                 due_at: assignment.due_at,
+                extension_due_at: assignment.extension_due_at,
+                effective_due_at: assignment.effective_due_at,
                 deadline_type: assignment.deadline_type,
                 points: assignment.points,
                 created_by: assignment.created_by,
@@ -100,6 +122,22 @@ impl AssignmentRepositoryTrait for FakeAssignmentRepository {
         }
         let store = self.store.lock().await;
         Ok(store.get(&id).cloned())
+    }
+
+    async fn find_by_id_for_student(
+        &self,
+        id: Uuid,
+        student_id: Uuid,
+    ) -> Result<Option<Assignment>, sqlx::Error> {
+        let mut assignment = self.find_by_id(id).await?;
+        let extensions = self.student_extensions.lock().await;
+        if let Some(assignment_value) = &mut assignment
+            && let Some(extension) = extensions.get(&(id, student_id))
+        {
+            assignment_value.extension_due_at = Some(extension.due_at);
+            assignment_value.effective_due_at = Some(extension.due_at);
+        }
+        Ok(assignment)
     }
 
     async fn list_attachments(
@@ -121,6 +159,58 @@ impl AssignmentRepositoryTrait for FakeAssignmentRepository {
             return Err(sqlx::Error::RowNotFound);
         }
         Ok(self.list_student_submission_history_result.clone())
+    }
+
+    async fn list_student_extensions(
+        &self,
+        assignment_id: Uuid,
+    ) -> Result<Vec<StudentAssignmentExtension>, sqlx::Error> {
+        if self.fail_student_extension_ops {
+            return Err(sqlx::Error::RowNotFound);
+        }
+        let extensions = self.student_extensions.lock().await;
+        Ok(extensions
+            .values()
+            .filter(|extension| extension.assignment_id == assignment_id)
+            .cloned()
+            .collect())
+    }
+
+    async fn upsert_student_extension(
+        &self,
+        extension: UpsertStudentAssignmentExtensionDto,
+    ) -> Result<StudentAssignmentExtension, sqlx::Error> {
+        if self.fail_student_extension_ops {
+            return Err(sqlx::Error::RowNotFound);
+        }
+        let now = Utc::now();
+        let entity = StudentAssignmentExtension {
+            assignment_id: extension.assignment_id,
+            student_id: extension.student_id,
+            due_at: extension.due_at,
+            created_by: Some(extension.modified_by),
+            created_at: now,
+            modified_by: Some(extension.modified_by),
+            modified_at: now,
+        };
+        let mut extensions = self.student_extensions.lock().await;
+        extensions.insert(
+            (extension.assignment_id, extension.student_id),
+            entity.clone(),
+        );
+        Ok(entity)
+    }
+
+    async fn delete_student_extension(
+        &self,
+        assignment_id: Uuid,
+        student_id: Uuid,
+    ) -> Result<bool, sqlx::Error> {
+        if self.fail_student_extension_ops {
+            return Err(sqlx::Error::RowNotFound);
+        }
+        let mut extensions = self.student_extensions.lock().await;
+        Ok(extensions.remove(&(assignment_id, student_id)).is_some())
     }
 
     async fn add_attachment(
@@ -158,6 +248,8 @@ impl AssignmentRepositoryTrait for FakeAssignmentRepository {
             title: assignment.title,
             description: assignment.description,
             due_at: assignment.due_at,
+            extension_due_at: None,
+            effective_due_at: assignment.due_at,
             deadline_type: assignment.deadline_type,
             points: Some(100),
             created_by: Some(assignment.modified_by),
@@ -190,6 +282,7 @@ impl AssignmentRepositoryTrait for FakeAssignmentRepository {
         existing.title = assignment.title;
         existing.description = assignment.description;
         existing.due_at = assignment.due_at;
+        existing.effective_due_at = assignment.due_at;
         existing.deadline_type = assignment.deadline_type;
         existing.modified_by = Some(assignment.modified_by);
         existing.modified_at = Some(Utc::now());
@@ -217,6 +310,8 @@ fn seed_assignment(id: Uuid) -> Assignment {
         title: "assignment-1".to_string(),
         description: Some("description".to_string()),
         due_at: Some(Utc::now()),
+        extension_due_at: None,
+        effective_due_at: Some(Utc::now()),
         deadline_type: AssignmentDeadlineType::SoftDeadline,
         points: Some(100),
         created_by: Some(user_id),
@@ -259,6 +354,43 @@ async fn get_by_id_returns_not_found_error_when_missing() {
         .expect_err("missing assignment should error");
 
     assert!(matches!(err, AppError::NotFound(_)));
+}
+
+#[tokio::test]
+async fn find_by_id_for_student_returns_extension_when_present() {
+    let assignment_id = Uuid::new_v4();
+    let student_id = Uuid::new_v4();
+    let extension_due_at = Utc::now() + chrono::Duration::days(1);
+    let mut map = HashMap::new();
+    map.insert(assignment_id, seed_assignment(assignment_id));
+    let mut extensions = HashMap::new();
+    extensions.insert(
+        (assignment_id, student_id),
+        StudentAssignmentExtension {
+            assignment_id,
+            student_id,
+            due_at: extension_due_at,
+            created_by: Some(student_id),
+            created_at: Utc::now(),
+            modified_by: Some(student_id),
+            modified_at: Utc::now(),
+        },
+    );
+    let repo = FakeAssignmentRepository {
+        store: Mutex::new(map),
+        student_extensions: Mutex::new(extensions),
+        ..Default::default()
+    };
+    let service = build_service_with_repo(repo);
+
+    let assignment = service
+        .find_by_id_for_student(assignment_id, student_id)
+        .await
+        .expect("student lookup should succeed")
+        .expect("assignment should exist");
+
+    assert_eq!(assignment.extension_due_at, Some(extension_due_at));
+    assert_eq!(assignment.effective_due_at, Some(extension_due_at));
 }
 
 #[tokio::test]

--- a/apps/web/tests/domains/auth/test_web_routes_auth.rs
+++ b/apps/web/tests/domains/auth/test_web_routes_auth.rs
@@ -15,7 +15,10 @@ use grade_o_matic_web::{
     domains::assignments::{
         AssignmentAttachment, AssignmentDeadlineType, AssignmentServiceTrait,
         StudentAssignmentSubmission,
-        dto::assignment_dto::{AssignmentDto, AssignmentWithAttachmentCountDto},
+        dto::assignment_dto::{
+            AssignmentDto, AssignmentWithAttachmentCountDto, StudentAssignmentExtensionDto,
+            UpsertStudentAssignmentExtensionDto,
+        },
     },
     domains::auth::AuthServiceTrait,
     domains::auth::dto::auth_dto::AuthUserDto,
@@ -318,6 +321,8 @@ impl AssignmentServiceTrait for FakeAssignmentService {
                     title: "Homework 1".to_string(),
                     description: Some("Ownership and borrowing".to_string()),
                     due_at: None,
+                    extension_due_at: None,
+                    effective_due_at: None,
                     deadline_type: AssignmentDeadlineType::SoftDeadline,
                     points: Some(100),
                 },
@@ -327,6 +332,8 @@ impl AssignmentServiceTrait for FakeAssignmentService {
                     title: "Locked Homework".to_string(),
                     description: Some("Deadline has passed".to_string()),
                     due_at: Some(Utc::now() - Duration::minutes(10)),
+                    extension_due_at: None,
+                    effective_due_at: Some(Utc::now() - Duration::minutes(10)),
                     deadline_type: AssignmentDeadlineType::HardCutoff,
                     points: Some(50),
                 },
@@ -340,12 +347,32 @@ impl AssignmentServiceTrait for FakeAssignmentService {
                 title: "Hidden Homework".to_string(),
                 description: Some("Should never be visible to this student".to_string()),
                 due_at: None,
+                extension_due_at: None,
+                effective_due_at: None,
                 deadline_type: AssignmentDeadlineType::SoftDeadline,
                 points: Some(50),
             }]);
         }
 
         Ok(vec![])
+    }
+
+    async fn list_by_class_for_student(
+        &self,
+        class_id: Uuid,
+        student_id: Uuid,
+    ) -> Result<Vec<AssignmentDto>, AppError> {
+        let mut assignments = self.list_by_class(class_id).await?;
+        if student_id == enrolled_student_id() {
+            for assignment in &mut assignments {
+                if assignment.id == hard_cutoff_assignment_id() {
+                    let due_at = Utc::now() - Duration::minutes(10);
+                    assignment.due_at = Some(due_at);
+                    assignment.effective_due_at = Some(due_at);
+                }
+            }
+        }
+        Ok(assignments)
     }
 
     async fn list_by_class_with_attachment_count(
@@ -359,6 +386,8 @@ impl AssignmentServiceTrait for FakeAssignmentService {
                 title: "Midterm Project".to_string(),
                 description: Some("Build a service".to_string()),
                 due_at: None,
+                extension_due_at: None,
+                effective_due_at: None,
                 deadline_type: AssignmentDeadlineType::HardCutoff,
                 points: Some(200),
                 attachment_count: 0,
@@ -432,6 +461,39 @@ impl AssignmentServiceTrait for FakeAssignmentService {
         Ok(vec![])
     }
 
+    async fn list_student_extensions(
+        &self,
+        assignment_id: Uuid,
+    ) -> Result<Vec<StudentAssignmentExtensionDto>, AppError> {
+        if assignment_id == instructor_assignment_id() {
+            return Ok(vec![StudentAssignmentExtensionDto {
+                assignment_id,
+                student_id: enrolled_student_id(),
+                due_at: Utc::now() + Duration::days(2),
+            }]);
+        }
+        Ok(vec![])
+    }
+
+    async fn upsert_student_extension(
+        &self,
+        extension: UpsertStudentAssignmentExtensionDto,
+    ) -> Result<StudentAssignmentExtensionDto, AppError> {
+        Ok(StudentAssignmentExtensionDto {
+            assignment_id: extension.assignment_id,
+            student_id: extension.student_id,
+            due_at: extension.due_at,
+        })
+    }
+
+    async fn delete_student_extension(
+        &self,
+        _assignment_id: Uuid,
+        _student_id: Uuid,
+    ) -> Result<bool, AppError> {
+        Ok(true)
+    }
+
     async fn attach_file(
         &self,
         _assignment_id: Uuid,
@@ -453,6 +515,8 @@ impl AssignmentServiceTrait for FakeAssignmentService {
                 title: "Homework 1".to_string(),
                 description: Some("Ownership and borrowing".to_string()),
                 due_at: None,
+                extension_due_at: None,
+                effective_due_at: None,
                 deadline_type: AssignmentDeadlineType::SoftDeadline,
                 points: Some(100),
             }));
@@ -464,6 +528,8 @@ impl AssignmentServiceTrait for FakeAssignmentService {
                 title: "Locked Homework".to_string(),
                 description: Some("Deadline has passed".to_string()),
                 due_at: Some(Utc::now() - Duration::minutes(10)),
+                extension_due_at: None,
+                effective_due_at: Some(Utc::now() - Duration::minutes(10)),
                 deadline_type: AssignmentDeadlineType::HardCutoff,
                 points: Some(50),
             }));
@@ -475,11 +541,21 @@ impl AssignmentServiceTrait for FakeAssignmentService {
                 title: "Midterm Project".to_string(),
                 description: Some("Build a service".to_string()),
                 due_at: None,
+                extension_due_at: None,
+                effective_due_at: None,
                 deadline_type: AssignmentDeadlineType::HardCutoff,
                 points: Some(200),
             }));
         }
         Ok(None)
+    }
+
+    async fn find_by_id_for_student(
+        &self,
+        id: Uuid,
+        _student_id: Uuid,
+    ) -> Result<Option<AssignmentDto>, AppError> {
+        self.find_by_id(id).await
     }
 
     async fn create(
@@ -499,6 +575,8 @@ impl AssignmentServiceTrait for FakeAssignmentService {
             title: _assignment.title,
             description: _assignment.description,
             due_at: _assignment.due_at,
+            extension_due_at: None,
+            effective_due_at: _assignment.due_at,
             deadline_type: _assignment.deadline_type,
             points: _assignment.points,
         })
@@ -1434,7 +1512,12 @@ async fn edit_assignment_page_happy_path_renders_form() {
     let html = body_to_string(response.into_body()).await;
     assert!(html.contains("Edit Assignment"));
     assert!(html.contains("Midterm Project"));
-    assert!(html.contains("Student Submission History"));
+    assert!(html.contains("Student Extensions"));
+    assert!(html.contains("Save Extension"));
+    assert!(
+        html.contains("/ui/instructors/assignments/77777777-7777-7777-7777-777777777777/students/")
+    );
+    assert!(html.contains("/extension"));
     assert!(html.contains("View History"));
 }
 


### PR DESCRIPTION
Resolves #26

## Overview
Adds instructor-managed assignment extensions for individual students while preserving the assignment's default class due date. Student-facing pages now show the effective due date, submission lateness is calculated
against any applicable extension, and instructors can review extension details alongside student submission history.

## Details
- Added `assignment_student_extensions` persistence for per-student due date overrides.
- Extended the assignment domain/service/repository layers to:
- look up assignments with student-specific effective due dates
- create/update student extensions
- delete student extensions
- list student extensions for instructor workflows
- Updated student assignment pages to display the effective due date and extension status.
- Updated submission deadline enforcement and late-submission calculation to use the effective due date instead of only the base assignment due date.
- Added instructor UI controls on the assignment edit page for saving/removing individual student extensions.
- Added instructor submission-history context showing default due date, extension due date, and effective due date.
- Updated tests to cover the new service/repository behavior and UI assertions.

## Changes outside the codebase
- Added a new database migration:
- `apps/web/migrations/20260317193000_create_assignment_student_extensions.sql`

## Additional information
- The assignment `due_at` field remains the default deadline for the class.
- Student extensions are modeled as overrides, which keeps existing assignment editing behavior intact and minimizes impact on unrelated code paths.
- Verified with:
- `cargo check`
- `cargo test -p grade-o-matic-web -- --nocapture`
- `cargo test -p libgrader -- --nocapture`

### Checklist

- [x] I have run this code in development, and it appears to resolve the stated issue.
- [ ] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval.
- [x] My pull request represents one logical piece of work.
- [x] My commits are related to the pull request and look clean.
- [x] I have added appropriate tests and documentation to any new models.
- [ ] I have updated the README file if appropriate.